### PR TITLE
Pull in and discontinue develop branch

### DIFF
--- a/client/src/utils/queryUtils.js
+++ b/client/src/utils/queryUtils.js
@@ -22,7 +22,7 @@ export const assembleSearchRequest = (state, granules, retrieveFacets) => {
     assembleAdditionalFilters(search)
   )
   if (granules) {
-    filters = _.concat(assembleSelectedCollectionsFilters(search))
+    filters = _.concat(filters, assembleSelectedCollectionsFilters(search))
   }
   filters =  _.flatten(_.compact(filters))
 


### PR DESCRIPTION
This is a follow up PR to #179 wherein we remove the develop branch and switch back to developing against master.

FYI for @cedardevs/foamcat developers! Develop against master from now on!