### PR TITLE
199 url warning

### DIFF
--- a/client/src/common/link/LinkComponent.jsx
+++ b/client/src/common/link/LinkComponent.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import ReactDOM from 'react-dom'
+import {isGovExternal} from '../../utils/urlUtils'
 import './link.css'
 
 class LinkComponent extends React.Component {
@@ -7,30 +7,37 @@ class LinkComponent extends React.Component {
     super(props)
   }
 
-  generateLink() {
-    const leavingSiteMsg = `You are exiting an NCEI website.
-\nThank you for visiting our site. We have provided\
- a link because it has information that may interest you. NCEI does not\
- endorse the views expressed, the information presented, or any commercial\
- products that may be advertised or available on that site`
-
-    const { host } = location
-    let { href } = this.props
-    if (href && href.split('/', 3).includes(host)) {
-      return <a></a>
-    } else {
-      let {href, ...aProps} = this.props
-      return <a {...aProps}
-        onClick={()=> {
-          if (window.confirm(leavingSiteMsg)) {
-            window.location.href = href
-          }
-        }}></a>
-    }
+  render() {
+    const { href, target, onClick, ...others } = this.props
+    return <a
+        href={href}
+        target={target}
+        onClick={this.buildOnClick(href, target, onClick)}
+        {...others}>
+      {this.props.children}
+    </a>
   }
 
-  render() {
-    return this.generateLink()
+  buildOnClick(href, target, onClick) {
+    const leavingSiteMsg = `The site you are navigating to is not hosted by the US Government.
+
+Thank you for visiting our site. We have provided \
+this link because it has information that may interest you, but we do not \
+endorse the views expressed, the information presented, or any commercial \
+products that may be advertised or available on that site.`
+
+    return (e) => {
+      if (typeof onClick === 'function') {
+        onClick()
+      }
+
+      if (isGovExternal(href)) {
+        e.preventDefault()
+        if (window.confirm(leavingSiteMsg)) {
+          target ? window.open(href, target) : window.location.href = href
+        }
+      }
+    }
   }
 }
 

--- a/client/src/root/FooterComponent.jsx
+++ b/client/src/root/FooterComponent.jsx
@@ -52,7 +52,7 @@ class FooterComponent  extends React.Component {
                   </div>
                 </div>
                 <div className={`${styles.versionInfo}`}>
-                  <A href ="https://github.com/cedardevs/onestop/releases" >
+                  <A target="_blank" href ="https://github.com/cedardevs/onestop/releases" >
                     Version: {strippedVersion} <img src={github} className={styles.github} aria-hidden="true"></img>
                   </A>
                 </div>

--- a/client/src/utils/urlUtils.js
+++ b/client/src/utils/urlUtils.js
@@ -8,3 +8,10 @@ export const processUrl = (url) => {
     return url
   }
 }
+
+// returns true of the url points outside the .gov domain
+export const isGovExternal = (url) => {
+  const isAbsolute = url.match(/^([a-zA-Z]+:)?\/\//) !== null
+  const isGov = url.match(/^([a-zA-Z]+:)?\/\/[^/]+\.gov/) !== null
+  return isAbsolute && !isGov
+}

--- a/client/test/utils/urlUtilsSpec.js
+++ b/client/test/utils/urlUtilsSpec.js
@@ -1,0 +1,27 @@
+import '../specHelper'
+import * as urlUtils from '../../src/utils/urlUtils'
+
+describe('The URL Utils', function () {
+  it('identify external urls', function () {
+    const urls = [
+        '//www.google.com',
+        'http://www.google.com',
+        'https://www.google.com',
+        'ftp://www.google.com',
+        'ftps://www.google.com'
+    ]
+
+    urls.forEach((url) => urlUtils.isGovExternal(url).should.equal(true, `Failed for url: ${url}`))
+  })
+
+  it('identify internal urls', function () {
+    const urls = [
+        '/search',
+        '//www.ngdc.noaa.gov',
+        'http://www.ngdc.noaa.gov',
+        'https://www.ngdc.noaa.gov'
+    ]
+
+    urls.forEach((url) => urlUtils.isGovExternal(url).should.equal(false, `Failed for url: ${url}`))
+  })
+})


### PR DESCRIPTION
Fixes #199 

Note: I think this also fixes the fact that the `here` link in the help wasn't being styled; it's `href` attribute wasn't being rendered, so it wasn't being colored like a link.