### PR TITLE
211 remove blue halos

### DIFF
--- a/client/src/result/collections/CollectionTileComponent.jsx
+++ b/client/src/result/collections/CollectionTileComponent.jsx
@@ -12,9 +12,8 @@ class CollectionTile extends React.Component {
 
   render() {
     return <div className={styles.tileContainer}
-      onKeyPress={(e)=>this.handleKeyPress(e, this.props.onCardClick)}
-      tabIndex={0}>
-      <div className={styles.tileContent} style={this.thumbnailStyle()}>
+      onKeyPress={(e)=>this.handleKeyPress(e, this.props.onCardClick)}>
+      <div className={styles.tileContent} style={this.thumbnailStyle()} tabIndex={0}>
         <div className={styles.overlay} onClick={() => this.props.onCardClick()}
           >
           <h2 className={styles.title}>{this.props.title}</h2>

--- a/client/src/result/granules/list/GranuleListComponent.jsx
+++ b/client/src/result/granules/list/GranuleListComponent.jsx
@@ -48,11 +48,11 @@ class GranuleList extends React.Component {
         .value()
 
     return (
-      <div ref={granuleFocus=>this.granuleFocus=granuleFocus} tabIndex={0}>
+      <div ref={granuleFocus=>this.granuleFocus=granuleFocus}>
         <a className={styles.navLink}
           tabIndex={0}
           onClick={this.props.showCollections}>Return To Collection Results</a>
-        <div className={`pure-g ${styles.mainWindow}`}>
+        <div className={`pure-g ${styles.mainWindow}`} tabIndex={0}>
           <div className={`pure-u-1-2 ${styles.map}`}>
             <MapContainer style={styles.mapContainer}/>
           </div>


### PR DESCRIPTION
Turns out the halos are the default focus ring that the browser is applying. Just had to move a couple `tabindex` attributes so they were directly associated with the things that we want to focus and hence the ring doesn't end up floating out in space on the page.

Resolves #211 