### PR TITLE
Add a max zoom to the main map component

### DIFF
--- a/client/src/search/map/MapComponent.jsx
+++ b/client/src/search/map/MapComponent.jsx
@@ -54,7 +54,7 @@ class MapComponent extends React.Component {
       // Define map with defaults
       map: L.map(ReactDOM.findDOMNode(this), {
         minZoom: 2,
-        maxZoom: 20,
+        maxZoom: 5,
         layers: [
             L.esri.basemapLayer("Oceans"),
             L.esri.basemapLayer("OceansLabels")


### PR DESCRIPTION
I'm letting it zoom in further than the thumbnail map because the full maps are big enough to still give you enough context. Note that this also applies to the drop-down map for drawing a spatial filter.

I could be convinced that 6 is a better number. Would be nice for someone else to take a look.

Resolves #210 