### PR TITLE
Truncate long descriptions

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -27,6 +27,7 @@
     "react-day-picker": "^2.4.1",
     "react-dom": "^15.3.0",
     "react-hot-loader": "^3.0.0-beta.6",
+    "react-show-more": "^1.1.1",
     "react-redux": "^4.4.5",
     "react-router": "^3.0.0",
     "react-router-redux": "^4.0.7",

--- a/client/src/detail/DetailComponent.jsx
+++ b/client/src/detail/DetailComponent.jsx
@@ -41,8 +41,8 @@ class Detail extends React.Component {
           <div className={`pure-u-1 pure-u-md-2-3`}>
             <div className={`pure-g`}>
               <div className={`pure-u-1 ${styles.underscored}`}>
-                <ShowMore lines={5} more="Show more..."
-                          anchorClass={`${styles.showMore} pure-button button-small`}>
+                <ShowMore lines={5}
+                          anchorClass={`${styles.showMore}`}>
                   {item.description}
                 </ShowMore>
               </div>

--- a/client/src/detail/DetailComponent.jsx
+++ b/client/src/detail/DetailComponent.jsx
@@ -1,4 +1,5 @@
 import React, {PropTypes} from 'react'
+import ShowMore from 'react-show-more'
 import MapThumbnailComponent from '../common/MapThumbnailComponent'
 import {processUrl} from '../utils/urlUtils'
 import infoCircle from 'fa/info-circle.svg'
@@ -40,7 +41,10 @@ class Detail extends React.Component {
           <div className={`pure-u-1 pure-u-md-2-3`}>
             <div className={`pure-g`}>
               <div className={`pure-u-1 ${styles.underscored}`}>
-                <p>{item.description}</p>
+                <ShowMore lines={5} more="Show more..."
+                          anchorClass={`${styles.showMore} pure-button button-small`}>
+                  {item.description}
+                </ShowMore>
               </div>
             </div>
             <div className={`${styles.underscored}`}>

--- a/client/src/detail/detail.css
+++ b/client/src/detail/detail.css
@@ -36,11 +36,11 @@
 .showMore {
   display: block;
   color: white;
-  background: black !important;
-  text-align: center;
+  text-align: right;
   font-style: italic;
   font-weight: bold;
   text-decoration: underline;
+  padding: .5 em;
 }
 
 .header {

--- a/client/src/detail/detail.css
+++ b/client/src/detail/detail.css
@@ -29,7 +29,18 @@
 .underscored {
   border-bottom: 1px solid $color-gray;
   margin-bottom: 1em;
+  padding-bottom: 1em;
   text-align: justify;
+}
+
+.showMore {
+  display: block;
+  color: white;
+  background: black !important;
+  text-align: center;
+  font-style: italic;
+  font-weight: bold;
+  text-decoration: underline;
 }
 
 .header {


### PR DESCRIPTION
I found a small, simple react component which figures out how many lines long a block of text is and truncates it.

I played around with the styling a fair amount but ended up doing something very simple because I thought it fit better than other things I was trying (buttons, arrows, etc). I'm certainly open to other ideas on styling if you have them.

Also I thought about trying to do something about how wide the paragraphs get, but decided that there really wasn't a good way to do that without something else to put to the right of the descriptions. In the future we'll index citation information and put that there as requested, but I don't think there's anything else that fits well there at the moment.

Resolves #208, at least for the time being until we add citation info.