### PR TITLE
image tag 'latest-SNAPSHOT'

### DIFF
--- a/api-metadata/build.gradle
+++ b/api-metadata/build.gradle
@@ -114,7 +114,9 @@ task dockerImage(type: Exec, description: 'Creates a docker image with the curre
       "--build-arg DATE=${getDateTime()} " +
       "--build-arg JAR_NAME=${rootProject.name}-${project.name}-all " +
       "-t cedardevs/${rootProject.name}-${project.name}:${project.version} . && " +
-      "docker tag cedardevs/${rootProject.name}-${project.name}:${project.version} cedardevs/${rootProject.name}-${project.name}:latest"]
+      "docker tag cedardevs/${rootProject.name}-${project.name}:${project.version} cedardevs/${rootProject.name}-${project.name}:latest && " +
+      "docker tag cedardevs/${rootProject.name}-${project.name}:${project.version} cedardevs/${rootProject.name}-${project.name}:latest-SNAPSHOT"
+      ]
 }
 
 assemble.dependsOn dockerImage
@@ -124,6 +126,7 @@ task publishImage(type: Exec, description: 'Publishes the docker image', group: 
   executable = "bash"
   args = ["-c", "docker login -u \$DOCKER_USER -p \$DOCKER_PASSWORD && " +
       "docker push cedardevs/${rootProject.name}-${project.name}:${project.version} && " +
+      "docker push cedardevs/${rootProject.name}-${project.name}:latest-SNAPSHOT && " +
       "docker logout"]
 }
 

--- a/api-metadata/build.gradle
+++ b/api-metadata/build.gradle
@@ -113,9 +113,10 @@ task dockerImage(type: Exec, description: 'Creates a docker image with the curre
       "--build-arg VERSION=${project.version} " +
       "--build-arg DATE=${getDateTime()} " +
       "--build-arg JAR_NAME=${rootProject.name}-${project.name}-all " +
-      "-t cedardevs/${rootProject.name}-${project.name}:${project.version} . && " +
-      "docker tag cedardevs/${rootProject.name}-${project.name}:${project.version} cedardevs/${rootProject.name}-${project.name}:latest && " +
-      "docker tag cedardevs/${rootProject.name}-${project.name}:${project.version} cedardevs/${rootProject.name}-${project.name}:latest-SNAPSHOT"
+      "-t cedardevs/${rootProject.name}-${project.name}:${project.version} " +
+      "-t cedardevs/${rootProject.name}-${project.name}:latest " +
+      "-t cedardevs/${rootProject.name}-${project.name}:latest-SNAPSHOT " +
+      "."
       ]
 }
 

--- a/api-search/build.gradle
+++ b/api-search/build.gradle
@@ -120,9 +120,10 @@ task dockerImage(type: Exec, description: 'Creates a docker image with the curre
     "--build-arg VERSION=${project.version} " +
     "--build-arg DATE=${getDateTime()} " +
     "--build-arg JAR_NAME=${rootProject.name}-${project.name}-all " +
-    "-t cedardevs/${rootProject.name}-${project.name}:${project.version} . && " +
-    "docker tag cedardevs/${rootProject.name}-${project.name}:${project.version} cedardevs/${rootProject.name}-${project.name}:latest && " +
-    "docker tag cedardevs/${rootProject.name}-${project.name}:${project.version} cedardevs/${rootProject.name}-${project.name}:latest-SNAPSHOT"
+    "-t cedardevs/${rootProject.name}-${project.name}:${project.version} " +
+    "-t cedardevs/${rootProject.name}-${project.name}:latest " +
+    "-t cedardevs/${rootProject.name}-${project.name}:latest-SNAPSHOT " +
+    "."
     ]
 }
 

--- a/api-search/build.gradle
+++ b/api-search/build.gradle
@@ -121,7 +121,9 @@ task dockerImage(type: Exec, description: 'Creates a docker image with the curre
     "--build-arg DATE=${getDateTime()} " +
     "--build-arg JAR_NAME=${rootProject.name}-${project.name}-all " +
     "-t cedardevs/${rootProject.name}-${project.name}:${project.version} . && " +
-    "docker tag cedardevs/${rootProject.name}-${project.name}:${project.version} cedardevs/${rootProject.name}-${project.name}:latest"]
+    "docker tag cedardevs/${rootProject.name}-${project.name}:${project.version} cedardevs/${rootProject.name}-${project.name}:latest && " +
+    "docker tag cedardevs/${rootProject.name}-${project.name}:${project.version} cedardevs/${rootProject.name}-${project.name}:latest-SNAPSHOT"
+    ]
 }
 
 assemble.dependsOn dockerImage
@@ -131,6 +133,7 @@ task publishImage(type: Exec, description: 'Publishes the docker image', group: 
   executable = "bash"
   args = ["-c", "docker login -u \$DOCKER_USER -p \$DOCKER_PASSWORD && " +
       "docker push cedardevs/${rootProject.name}-${project.name}:${project.version} && " +
+      "docker push cedardevs/${rootProject.name}-${project.name}:latest-SNAPSHOT && " +
       "docker logout"]
 }
 

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -100,7 +100,9 @@ task dockerImage(type: Exec, description: 'Creates a docker image with the curre
       "--build-arg VERSION=${project.version} " +
       "--build-arg DATE=${getDateTime()} " +
       "-t cedardevs/${rootProject.name}-${project.name}:${project.version} . && " +
-      "docker tag cedardevs/${rootProject.name}-${project.name}:${project.version} cedardevs/${rootProject.name}-${project.name}:latest"]
+      "docker tag cedardevs/${rootProject.name}-${project.name}:${project.version} cedardevs/${rootProject.name}-${project.name}:latest && " +
+      "docker tag cedardevs/${rootProject.name}-${project.name}:${project.version} cedardevs/${rootProject.name}-${project.name}:latest-SNAPSHOT"
+      ]
 }
 
 assemble.dependsOn dockerImage
@@ -110,6 +112,7 @@ task publishImage(type: Exec, description: 'Publishes the docker image', group: 
   executable = "bash"
   args = ["-c", "docker login -u \$DOCKER_USER -p \$DOCKER_PASSWORD && " +
       "docker push cedardevs/${rootProject.name}-${project.name}:${project.version} && " +
+      "docker push cedardevs/${rootProject.name}-${project.name}:latest-SNAPSHOT && " +
       "docker logout"]
 }
 

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -99,9 +99,10 @@ task dockerImage(type: Exec, description: 'Creates a docker image with the curre
       "--build-arg VCS_REF=\$(git rev-parse --short HEAD) " +
       "--build-arg VERSION=${project.version} " +
       "--build-arg DATE=${getDateTime()} " +
-      "-t cedardevs/${rootProject.name}-${project.name}:${project.version} . && " +
-      "docker tag cedardevs/${rootProject.name}-${project.name}:${project.version} cedardevs/${rootProject.name}-${project.name}:latest && " +
-      "docker tag cedardevs/${rootProject.name}-${project.name}:${project.version} cedardevs/${rootProject.name}-${project.name}:latest-SNAPSHOT"
+      "-t cedardevs/${rootProject.name}-${project.name}:${project.version} " +
+      "-t cedardevs/${rootProject.name}-${project.name}:latest " +
+      "-t cedardevs/${rootProject.name}-${project.name}:latest-SNAPSHOT " +
+      "."
       ]
 }
 


### PR DESCRIPTION
Added a new tag for docker images: 'latest-SNAPSHOT', which will be the primary tag for CU deployment. This should be pushed to docker hub with every successful build.

The current travis build will only actually push latest snapshot images to docker hub when we merge it to master.