### PR TITLE
255 Feature/collection summary view

### DIFF
--- a/client/src/common/MapThumbnailComponent.jsx
+++ b/client/src/common/MapThumbnailComponent.jsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom'
 import L from 'leaflet'
 import 'esri-leaflet'
 import _ from 'lodash'
-import { ensurePolygon } from '../utils/geoUtils'
+import { ensureDatelineFriendlyPolygon } from '../utils/geoUtils'
 
 class MapThumbnailComponent extends React.Component {
   constructor(props) {
@@ -27,7 +27,7 @@ class MapThumbnailComponent extends React.Component {
 
     const geoJsonLayer = L.GeoJSON.geometryToLayer({
       type: "Feature",
-      geometry: ensurePolygon(this.props.geometry) // allows use of setStyle, which does not exist for GeoJSON points
+      geometry: ensureDatelineFriendlyPolygon(this.props.geometry) // allows use of setStyle, which does not exist for GeoJSON points
     })
     geoJsonLayer.setStyle({
       color: "red",

--- a/client/src/common/MapThumbnailComponent.jsx
+++ b/client/src/common/MapThumbnailComponent.jsx
@@ -2,7 +2,6 @@ import React, { PropTypes } from 'react'
 import ReactDOM from 'react-dom'
 import L from 'leaflet'
 import 'esri-leaflet'
-import { convertEnvelopeToPolygon } from '../utils/geoUtils'
 
 class MapThumbnailComponent extends React.Component {
   constructor(props) {
@@ -22,13 +21,15 @@ class MapThumbnailComponent extends React.Component {
 
     const geoJsonLayer = L.GeoJSON.geometryToLayer({
       type: "Feature",
-      geometry: convertEnvelopeToPolygon(this.props.geometry)
+      geometry: this.props.geometry
     })
-    geoJsonLayer.setStyle({
-      color: "red",
-      weight: 5,
-      opacity: 1
-    })
+    if(this.props.geometry.type !== 'Point') {
+      geoJsonLayer.setStyle({
+        color: "red",
+        weight: 5,
+        opacity: 1
+      })
+    }
 
     this.map = L.map(ReactDOM.findDOMNode(this), {
       layers: [
@@ -49,7 +50,10 @@ class MapThumbnailComponent extends React.Component {
   }
 
   fitMapToResults(geoJsonLayer) {
-    if (this.props.geometry) {
+    if (this.props.geometry && this.props.geometry.type === 'Point') {
+      this.map.setView(this.props.geometry.coordinates, 2)
+    }
+    else if (this.props.geometry) {
       this.map.fitBounds(geoJsonLayer.getBounds())
     }
     else {

--- a/client/src/detail/DetailComponent.jsx
+++ b/client/src/detail/DetailComponent.jsx
@@ -3,6 +3,7 @@ import ShowMore from 'react-show-more'
 import A from 'LinkComponent'
 import styles from './detail-container.css'
 import SummaryView from "./SummaryView";
+import { processUrl } from '../utils/urlUtils'
 
 class Detail extends React.Component {
   constructor(props) {
@@ -21,7 +22,9 @@ class Detail extends React.Component {
     return <div className={styles.modal}>
       <div className={styles.modalContent}>
         <div className={`pure-g ${styles.header} ${styles.underscored}`}>
-          <div className={`pure-u-11-12 ${styles.title}`} title={`${item.title}`}>{item.title}</div>
+          <div className={`pure-u-11-12 ${styles.title}`} title={`${item.title}`}>
+            <ShowMore lines={1} anchorClass={`${styles.showMore}`}>{item.title}</ShowMore>
+          </div>
           <div className={'pure-u-1-12'}>
             <span className={styles.close} onClick={this.close}>x</span>
           </div>
@@ -30,10 +33,6 @@ class Detail extends React.Component {
       </div>
     </div>
 
-    // {/*<ShowMore lines={5}*/}
-    // {/*anchorClass={`${styles.showMore}`}>*/}
-    // {/*{item.description}*/}
-    // {/*</ShowMore>*/}
     // {/*{this.renderLinks('More Info', this.getLinksByType('information'), this.renderLink)}*/}
     // {/*{this.renderLinks('Data Access', this.getLinksByType('download'), this.renderLink)}*/}
   }

--- a/client/src/detail/DetailComponent.jsx
+++ b/client/src/detail/DetailComponent.jsx
@@ -1,5 +1,6 @@
 import React, {PropTypes} from 'react'
 import ShowMore from 'react-show-more'
+import _ from 'lodash'
 import A from 'LinkComponent'
 import styles from './detail-container.css'
 import SummaryView from "./SummaryView";
@@ -33,6 +34,10 @@ class Detail extends React.Component {
       </div>
     </div>
 
+    // console.log('geometry', this.props.item.spatialBounding)
+    // const imgUrl = processUrl(this.props.item.thumbnail)
+    // return imgUrl ?
+    //   <img className={styles.previewImg} src={imgUrl}/> :
     // {/*{this.renderLinks('More Info', this.getLinksByType('information'), this.renderLink)}*/}
     // {/*{this.renderLinks('Data Access', this.getLinksByType('download'), this.renderLink)}*/}
   }

--- a/client/src/detail/DetailComponent.jsx
+++ b/client/src/detail/DetailComponent.jsx
@@ -1,13 +1,8 @@
 import React, {PropTypes} from 'react'
 import ShowMore from 'react-show-more'
-import MapThumbnailComponent from '../common/MapThumbnailComponent'
-import {processUrl} from '../utils/urlUtils'
-import infoCircle from 'fa/info-circle.svg'
-import star from 'fa/star.svg'
-import starO from 'fa/star-o.svg'
-import starHalfO from 'fa/star-half-o.svg'
 import A from 'LinkComponent'
-import styles from './detail.css'
+import styles from './detail-container.css'
+import SummaryView from "./SummaryView";
 
 class Detail extends React.Component {
   constructor(props) {
@@ -15,7 +10,6 @@ class Detail extends React.Component {
 
     this.close = this.close.bind(this)
     this.handleKeyDown = this.handleKeyDown.bind(this)
-    this.renderKeyword = this.renderKeyword.bind(this)
   }
 
   render() {
@@ -27,38 +21,40 @@ class Detail extends React.Component {
     return <div className={styles.modal}>
       <div className={styles.modalContent}>
         <div className={`pure-g ${styles.header} ${styles.underscored}`}>
-          <div className={`pure-u-7-8 ${styles.title}`} title={`${item.title}`}>{item.title}</div>
-          <div className={'pure-u-1-8'}>
+          <div className={`pure-u-11-12 ${styles.title}`} title={`${item.title}`}>{item.title}</div>
+          <div className={'pure-u-1-12'}>
             <span className={styles.close} onClick={this.close}>x</span>
           </div>
         </div>
-        <div className={'pure-g'}>
-          <div className={`pure-u-1 pure-u-md-1-3`} style={{textAlign: 'center'}}>
-            {this.renderImage()}
-            {this.renderGranulesLink()}
-            {this.renderDSMMRating()}
-          </div>
-          <div className={`pure-u-1 pure-u-md-2-3`}>
-            <div className={`pure-g`}>
-              <div className={`pure-u-1 ${styles.underscored}`}>
-                <ShowMore lines={5}
-                          anchorClass={`${styles.showMore}`}>
-                  {item.description}
-                </ShowMore>
-              </div>
-            </div>
-            <div className={`${styles.underscored}`}>
-              {this.renderLinks('More Info', this.getLinksByType('information'), this.renderLink)}
-              {this.renderLinks('Data Access', this.getLinksByType('download'), this.renderLink)}
-            </div>
-            <div>
-              {this.renderLinks('Themes', this.getKeywordsByType('gcmdScience'), this.renderKeyword)}
-              {this.renderLinks('Places', this.getKeywordsByType('gcmdLocations'), this.renderKeyword)}
-            </div>
-          </div>
-        </div>
+        <SummaryView id={this.props.id} item={this.props.item}/>
       </div>
     </div>
+
+    // {/*<ShowMore lines={5}*/}
+    // {/*anchorClass={`${styles.showMore}`}>*/}
+    // {/*{item.description}*/}
+    // {/*</ShowMore>*/}
+    // {/*{this.renderLinks('More Info', this.getLinksByType('information'), this.renderLink)}*/}
+    // {/*{this.renderLinks('Data Access', this.getLinksByType('download'), this.renderLink)}*/}
+  }
+
+  close() {
+    this.props.dismiss()
+  }
+
+  handleKeyDown(event) {
+    if (event.keyCode === 27) { // esc
+      this.close()
+    }
+  }
+
+  componentWillUpdate(nextProps, nextState) {
+    if (nextProps.id) {
+      document.addEventListener("keydown", this.handleKeyDown, false);
+    }
+    else {
+      document.removeEventListener("keydown", this.handleKeyDown, false);
+    }
   }
 
   getLinks() {
@@ -85,124 +81,18 @@ class Detail extends React.Component {
   }
 
   renderLink(link, index) {
-   return <li className={'pure-u'} key={index}>
-     <A href={link.linkUrl} target="_blank"
-             className={`pure-button pure-button-primary`}>
-       {link.linkProtocol || 'Link'}
-     </A>
-   </li>
-  }
-
-  renderImage() {
-    const imgUrl = processUrl(this.props.item.thumbnail)
-    return imgUrl ?
-        <img className={styles.previewImg} src={imgUrl}/> :
-        <div className={styles.previewMap}>
-          <MapThumbnailComponent geometry={this.props.geometry}/>
-        </div>
-  }
-
-  getKeywordsByType(type) {
-    const keywords = this.props.item && this.props.item[type] || []
-    return keywords
-        .map((k) => k.split('>')) // split GCMD keywords apart
-        .reduce((list, keys) => list.concat(keys), []) // flatten
-        .map((k) => k.toLowerCase().trim()) // you can figure this one out
-        .filter((k, i, a) => a.indexOf(k) === i) // dedupe
-  }
-
-  renderKeyword(keyword, index) {
     return <li className={'pure-u'} key={index}>
-      <a className={`pure-button ${styles['button-secondary']}`}
-         onClick={() => this.props.textSearch(`"${keyword}"`)}>
-        {keyword}
-      </a>
+      <A href={link.linkUrl} target="_blank"
+         className={`pure-button pure-button-primary`}>
+        {link.linkProtocol || 'Link'}
+      </A>
     </li>
-  }
-
-  close() {
-    this.props.dismiss()
-  }
-
-  handleKeyDown(event) {
-    if (event.keyCode === 27) { // esc
-      this.close()
-    }
-  }
-
-  componentWillUpdate(nextProps, nextState) {
-    if (nextProps.id) {
-      document.addEventListener("keydown", this.handleKeyDown, false);
-    }
-    else {
-      document.removeEventListener("keydown", this.handleKeyDown, false);
-    }
   }
 
   renderGranulesLink() {
     return <a onClick={() => this.props.showGranules(this.props.id)} className={`pure-button pure-button-primary ${styles.granulesButton}`}>
       Show Matching Files
     </a>
-  }
-
-  renderDSMMRating() {
-    const dsmmScore = this.props.item.dsmmAverage
-    const fullStars = Math.floor(dsmmScore)
-    const halfStar = dsmmScore % 1 >= 0.5
-
-    const stars = []
-    if (dsmmScore === 0) {
-      stars.push(<span key={42} className={styles.dsmmMissing}>DSMM Rating Unavailable</span>)
-    }
-    else {
-      for (let i = 0; i < 5; i++) {
-        if (i < fullStars) {
-          stars.push(this.renderFullStar(i))
-        }
-        else if (i === fullStars && halfStar) {
-          stars.push(this.renderHalfStar(i))
-        }
-        else {
-          stars.push(this.renderEmptyStar(i))
-        }
-      }
-    }
-
-    return (
-        <div>
-          {stars}
-          <div className={`${styles.dsmmInfo}`}>
-            <img src={infoCircle} className={styles.infoCircle}></img>
-            <div className={`${styles.text}`}> This is the average DSMM rating of this collection.
-              The <A href="http://doi.org/10.2481/dsj.14-049" target="_blank" title="Data Stewardship Maturity Matrix Information">
-                Data Stewardship Maturity Matrix (DSMM)</A> is a unified framework that defines criteria for the following nine components based on measurable practices:
-              <ul>
-                <li>Accessibility</li>
-                <li>Data Integrity</li>
-                <li>Data Quality Assessment</li>
-                <li>Data Quality Assurance</li>
-                <li>Data Quality Control Monitoring</li>
-                <li>Preservability</li>
-                <li>Production Sustainability</li>
-                <li>Transparency Traceability</li>
-                <li>Usability</li>
-              </ul>
-            </div>
-          </div>
-        </div>
-    )
-  }
-
-  renderFullStar(i) {
-    return <img key={i} className={styles.star} src={star}></img>
-  }
-
-  renderHalfStar(i) {
-    return <img key={i} className={styles.star} src={starHalfO}></img>
-  }
-
-  renderEmptyStar(i) {
-    return <img key={i} className={styles.star} src={starO}></img>
   }
 }
 

--- a/client/src/detail/SummaryView.jsx
+++ b/client/src/detail/SummaryView.jsx
@@ -50,14 +50,15 @@ class SummaryView extends React.Component {
         <div className={styles.atAGlance}>Collection At A Glance</div>
         <div className={`pure-g`}>
           <div className={`pure-u-1-2`}>
-            <div className={styles.sectionHeading}>Time Period: </div>
-            <div>{startDate} to {endDate}</div>
-            <div className={styles.sectionHeading}>Spatial Bounding: </div>
+            <div className={styles.sectionHeading}>Time Period:</div>
+            <div>{startDate && endDate ? `${startDate} to ${endDate}` : 'Not Provided'}</div>
+            <div className={styles.sectionHeading}>Spatial Bounding Map:</div>
             <div className={styles.previewMap}>
               <MapThumbnailComponent geometry={this.props.item.spatialBounding} interactive={true}/>
             </div>
-            <div>Coordinates: TODO</div>
-            <div className={styles.sectionHeading}>DSMM Rating: </div>
+            <div className={styles.sectionHeading}>Bounding Coordinates:</div>
+            <div>{this.buildCoordinatesString()}</div>
+            <div className={styles.sectionHeading}>DSMM Rating:</div>
             {this.renderDSMMRating()}
           </div>
           <div className={`pure-u-1-2`}>
@@ -167,6 +168,18 @@ class SummaryView extends React.Component {
     }
   }
 
+  buildCoordinatesString() {
+    // For point, want: "Point at [0], [1] (longitude, latitude)"
+    // For polygon want: "Bounding box covering [0][0], [0][1], [2][0], [2][1] (N, W, S, E)"
+    const geometry = this.props.item.spatialBounding
+    const deg = '\u00B0'
+    if (geometry.type.toLowerCase() === 'point') {
+      return `Point at ${geometry.coordinates[0]}${deg}, ${geometry.coordinates[1]}${deg} (longitude, latitude).`
+    }
+    else {
+      return `Bounding box covering ${geometry.coordinates[0][0][0]}${deg}, ${geometry.coordinates[0][0][1]}${deg}, ${geometry.coordinates[0][2][0]}${deg}, ${geometry.coordinates[0][2][1]}${deg} (W, N, E, S).`
+    }
+  }
 }
 
 SummaryView.propTypes = {

--- a/client/src/detail/SummaryView.jsx
+++ b/client/src/detail/SummaryView.jsx
@@ -7,7 +7,7 @@ import starHalfO from 'fa/star-half-o.svg'
 import styles from './detail-views.css'
 import A from 'LinkComponent'
 import MapThumbnailComponent from '../common/MapThumbnailComponent'
-import { processUrl } from '../utils/urlUtils'
+
 
 class SummaryView extends React.Component {
   constructor(props) {
@@ -30,7 +30,6 @@ class SummaryView extends React.Component {
 
     const startDate = this.props.item.temporalBounding.beginDate
     const endDate = this.props.item.temporalBounding.endDate ? this.props.item.temporalBounding.endDate : 'present'
-    //const instruments = this.getKeywordsByType('gcmdInstruments').map ( k => <div className={styles.keyword2} key={k}>{k}</div> )
 
     return (
       <div>

--- a/client/src/detail/SummaryView.jsx
+++ b/client/src/detail/SummaryView.jsx
@@ -1,0 +1,163 @@
+import React, { PropTypes } from 'react'
+import _ from 'lodash'
+import infoCircle from 'fa/info-circle.svg'
+import star from 'fa/star.svg'
+import starO from 'fa/star-o.svg'
+import starHalfO from 'fa/star-half-o.svg'
+import styles from './detail-views.css'
+import A from 'LinkComponent'
+import MapThumbnailComponent from '../common/MapThumbnailComponent'
+import { processUrl } from '../utils/urlUtils'
+
+class SummaryView extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      showAll: false
+    }
+
+    this.handleShowAll = this.handleShowAll.bind(this);
+  }
+
+  handleShowAll() {
+    this.setState(prevState => {
+      showAll: !prevState.showAll
+    });
+  }
+
+
+  render() {
+
+    const startDate = this.props.item.temporalBounding.beginDate
+    const endDate = this.props.item.temporalBounding.endDate ? this.props.item.temporalBounding.endDate : 'present'
+    //const instruments = this.getKeywordsByType('gcmdInstruments').map ( k => <div className={styles.keyword2} key={k}>{k}</div> )
+
+    return (
+      <div>
+        <div className={styles.atAGlance}>Collection At A Glance</div>
+        <div className={`pure-g`}>
+          <div className={`pure-u-1-2`}>
+            <div className={styles.sectionHeading}>Time Period: </div>
+            <div>{startDate} to {endDate}</div>
+            <div className={styles.sectionHeading}>Spatial Bounding: </div>
+            {this.renderGeometryOnMap()}
+            <div>Coordinates: TODO</div>
+            <div className={styles.sectionHeading}>DSMM Rating: </div>
+            {this.renderDSMMRating()}
+          </div>
+          <div className={`pure-u-1-2`}>
+            <div className={styles.sectionHeading}>Themes:</div>
+            <div className={styles.keywords}>{this.renderGCMDKeywords('gcmdScience', '#008445')}</div>
+            <button onClick={()=>{this.handleShowAll()}}>blah</button>
+            <div className={styles.sectionHeading}>Instruments:</div>
+            <div className={styles.keywords}>{this.renderGCMDKeywords('gcmdInstruments', '#0965a1')}</div>
+            <div className={styles.sectionHeading}>Platforms:</div>
+            <div className={styles.keywords}>{this.renderGCMDKeywords('gcmdPlatforms', '#008445')}</div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  renderDSMMRating() {
+    const dsmmScore = this.props.item.dsmmAverage
+    const fullStars = Math.floor(dsmmScore)
+    const halfStar = dsmmScore % 1 >= 0.5
+
+    const stars = []
+    if (dsmmScore === 0) {
+      stars.push(<span key={42} className={styles.dsmmMissing}>DSMM Rating Unavailable</span>)
+    }
+    else {
+      for (let i = 0; i < 5; i++) {
+        if (i < fullStars) {
+          stars.push(this.renderFullStar(i))
+        }
+        else if (i === fullStars && halfStar) {
+          stars.push(this.renderHalfStar(i))
+        }
+        else {
+          stars.push(this.renderEmptyStar(i))
+        }
+      }
+    }
+
+    return (
+      <div>
+        {stars}
+        <div className={`${styles.dsmmInfo}`}>
+          <img src={infoCircle} className={styles.infoCircle}></img>
+          <div className={`${styles.text}`}> This is the average DSMM rating of this collection.
+            The <A href="http://doi.org/10.2481/dsj.14-049" target="_blank" title="Data Stewardship Maturity Matrix Information">
+              Data Stewardship Maturity Matrix (DSMM)</A> is a unified framework that defines criteria for the following nine components based on measurable practices:
+            <ul>
+              <li>Accessibility</li>
+              <li>Data Integrity</li>
+              <li>Data Quality Assessment</li>
+              <li>Data Quality Assurance</li>
+              <li>Data Quality Control Monitoring</li>
+              <li>Preservability</li>
+              <li>Production Sustainability</li>
+              <li>Transparency Traceability</li>
+              <li>Usability</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  renderFullStar(i) {
+    return <img key={i} className={styles.star} src={star}></img>
+  }
+
+  renderHalfStar(i) {
+    return <img key={i} className={styles.star} src={starHalfO}></img>
+  }
+
+  renderEmptyStar(i) {
+    return <img key={i} className={styles.star} src={starO}></img>
+  }
+
+  renderGeometryOnMap() {
+    // console.log('geometry', this.props.item.spatialBounding)
+    // const imgUrl = processUrl(this.props.item.thumbnail)
+    // return imgUrl ?
+    //   <img className={styles.previewImg} src={imgUrl}/> :
+      return <div className={styles.previewMap}>
+        <MapThumbnailComponent geometry={this.props.item.spatialBounding}/>
+      </div>
+  }
+
+  renderGCMDKeywords(type, bgColor) {
+    let keywords = this.props.item && this.props.item[type] || []
+
+    if (!_.isEmpty(keywords)) {
+      if (type === 'gcmdScience') {
+        keywords = keywords
+          .map((k) => k.split('>')) // split GCMD keywords apart
+          .reduce((list, keys) => list.concat(keys), []) // flatten
+          .map((k) => _.startCase(k.toLowerCase().trim())) // you can figure this one out
+          .filter((k, i, a) => a.indexOf(k) === i) // dedupe
+      }
+      else {
+        keywords = keywords
+          .map((k) => _.startCase(k.substring(k.indexOf('>') + 1).trim().toLowerCase()) ) // Format is 'SHORT NAME > Long Name' but handles if string doesn't have angle bracket
+      }
+
+      return keywords.map( (k, index) => index > 2 && !this.state.showAll ? null : <div className={styles.keyword} style={{backgroundColor: bgColor}} key={k}>{k}</div>  )
+    }
+
+    else {
+      return <div style={{fontStyle: 'italic', color: bgColor}}>None Provided</div>
+    }
+  }
+
+}
+
+SummaryView.propTypes = {
+  id: PropTypes.string,
+  item: PropTypes.object,
+}
+
+export default SummaryView

--- a/client/src/detail/SummaryView.jsx
+++ b/client/src/detail/SummaryView.jsx
@@ -13,23 +13,37 @@ class SummaryView extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
-      showAll: false
+      showAllThemes: false,
+      showAllInstruments: false,
+      showAllPlatforms: false
     }
 
-    this.handleShowAll = this.handleShowAll.bind(this);
+    this.handleShowGCMD = this.handleShowGCMD.bind(this)
   }
 
-  handleShowAll() {
-    this.setState(prevState => {
-      showAll: !prevState.showAll
-    });
+  handleShowGCMD(type) {
+    if (type === 'gcmdScience') {
+      this.setState({
+        showAllThemes: !this.state.showAllThemes
+      })
+    }
+    else if (type === 'gcmdInstruments') {
+      this.setState({
+        showAllInstruments: !this.state.showAllInstruments
+      })
+    }
+    else if (type === 'gcmdPlatforms') {
+      this.setState({
+        showAllPlatforms: !this.state.showAllPlatforms
+      })
+    }
   }
 
 
   render() {
 
     const startDate = this.props.item.temporalBounding.beginDate
-    const endDate = this.props.item.temporalBounding.endDate ? this.props.item.temporalBounding.endDate : 'present'
+    const endDate = this.props.item.temporalBounding.endDate ? this.props.item.temporalBounding.endDate : 'Present'
 
     return (
       <div>
@@ -39,19 +53,20 @@ class SummaryView extends React.Component {
             <div className={styles.sectionHeading}>Time Period: </div>
             <div>{startDate} to {endDate}</div>
             <div className={styles.sectionHeading}>Spatial Bounding: </div>
-            {this.renderGeometryOnMap()}
+            <div className={styles.previewMap}>
+              <MapThumbnailComponent geometry={this.props.item.spatialBounding} interactive={true}/>
+            </div>
             <div>Coordinates: TODO</div>
             <div className={styles.sectionHeading}>DSMM Rating: </div>
             {this.renderDSMMRating()}
           </div>
           <div className={`pure-u-1-2`}>
             <div className={styles.sectionHeading}>Themes:</div>
-            <div className={styles.keywords}>{this.renderGCMDKeywords('gcmdScience', '#008445')}</div>
-            <button onClick={()=>{this.handleShowAll()}}>blah</button>
+            {this.renderGCMDKeywords('gcmdScience', '#008445', this.state.showAllThemes)}
             <div className={styles.sectionHeading}>Instruments:</div>
-            <div className={styles.keywords}>{this.renderGCMDKeywords('gcmdInstruments', '#0965a1')}</div>
+            {this.renderGCMDKeywords('gcmdInstruments', '#0965a1', this.state.showAllInstruments)}
             <div className={styles.sectionHeading}>Platforms:</div>
-            <div className={styles.keywords}>{this.renderGCMDKeywords('gcmdPlatforms', '#008445')}</div>
+            {this.renderGCMDKeywords('gcmdPlatforms', '#008445', this.state.showAllPlatforms)}
           </div>
         </div>
       </div>
@@ -118,17 +133,7 @@ class SummaryView extends React.Component {
     return <img key={i} className={styles.star} src={starO}></img>
   }
 
-  renderGeometryOnMap() {
-    // console.log('geometry', this.props.item.spatialBounding)
-    // const imgUrl = processUrl(this.props.item.thumbnail)
-    // return imgUrl ?
-    //   <img className={styles.previewImg} src={imgUrl}/> :
-      return <div className={styles.previewMap}>
-        <MapThumbnailComponent geometry={this.props.item.spatialBounding}/>
-      </div>
-  }
-
-  renderGCMDKeywords(type, bgColor) {
+  renderGCMDKeywords(type, bgColor, showAll) {
     let keywords = this.props.item && this.props.item[type] || []
 
     if (!_.isEmpty(keywords)) {
@@ -143,8 +148,18 @@ class SummaryView extends React.Component {
         keywords = keywords
           .map((k) => _.startCase(k.substring(k.indexOf('>') + 1).trim().toLowerCase()) ) // Format is 'SHORT NAME > Long Name' but handles if string doesn't have angle bracket
       }
+      keywords = keywords.map( (k, index) => index > 2 && !showAll ? null : <div className={styles.keyword} style={{backgroundColor: bgColor}} key={k}>{k}</div>  )
 
-      return keywords.map( (k, index) => index > 2 && !this.state.showAll ? null : <div className={styles.keyword} style={{backgroundColor: bgColor}} key={k}>{k}</div>  )
+      if (keywords.length > 3) {
+        return ( <div>
+          <div className={styles.keywords}>{keywords}</div>
+            <div className={styles.showMoreButton} onClick={()=>{this.handleShowGCMD(type)}}>{!showAll ? 'Show All' : 'Collapse'}</div>
+          </div>
+        )
+      }
+      else {
+        return <div className={styles.keywords}>{keywords}</div>
+      }
     }
 
     else {

--- a/client/src/detail/detail-container.css
+++ b/client/src/detail/detail-container.css
@@ -1,0 +1,96 @@
+@import '../../style/style.css';
+
+.modal {
+  position: fixed;
+  z-index: 2;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: rgb(0, 0, 0);
+  background-color: rgba(0, 0, 0, 0.6);
+}
+
+.modalContent {
+  background-color: #000;
+  margin: 10% auto;
+  padding: 1.5em;
+  border: 1px solid $color-gray;
+  width: 90%;
+  max-width: 80em;
+  overflow: auto;
+
+  & p {
+    margin-top: 0;
+  }
+}
+
+.underscored {
+  border-bottom: 1px solid $color-gray;
+  margin-bottom: 1em;
+  padding-bottom: 1em;
+  text-align: justify;
+}
+
+.showMore {
+  display: block;
+  color: white;
+  text-align: right;
+  font-style: italic;
+  font-weight: bold;
+  text-decoration: underline;
+  padding: .5em;
+}
+
+.header {
+  font-size: 1.5em;
+  font-weight: bold;
+}
+
+.close {
+  color: $color-gray;
+  display: inline-block;
+  float: right;
+}
+.close:hover,
+.close:focus {
+  color: #fff;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.title {
+  position: relative;
+  max-height: 6em;
+  text-overflow: ellipsis;
+}
+
+.linkRow {
+  font-size: 1em;
+  font-weight: bold;
+
+  & span {
+    float: right;
+    margin-bottom: 1em;
+  }
+
+  & ul {
+    padding: 0;
+    margin: 0;
+    list-style-type: none;
+    & li {
+      margin-left: 1em;
+      margin-bottom: 1em;
+    }
+  }
+}
+
+.button-secondary {
+  color: white !important;
+  background: #00a6d2 !important;
+}
+
+.granulesButton {
+  margin-bottom: 1em;
+}

--- a/client/src/detail/detail-container.css
+++ b/client/src/detail/detail-container.css
@@ -29,16 +29,15 @@
 .underscored {
   border-bottom: 1px solid $color-gray;
   margin-bottom: 1em;
-  padding-bottom: 1em;
   text-align: justify;
 }
 
 .showMore {
+  font-size: 0.75em;
   display: block;
   color: white;
   text-align: right;
   font-style: italic;
-  font-weight: bold;
   text-decoration: underline;
   padding: .5em;
 }

--- a/client/src/detail/detail-views.css
+++ b/client/src/detail/detail-views.css
@@ -97,6 +97,17 @@ a {
   color: grey;
 }
 
+.showMoreButton {
+  text-align: right;
+  /*background-color: #be6a00;*/
+}
+
+.showMoreButton:hover,
+.showMoreButton:focus {
+  /*background-color: color(#be6a00 tint(15%));*/
+  cursor: pointer;
+}
+
 
 /*************************/
 /* Description View */

--- a/client/src/detail/detail-views.css
+++ b/client/src/detail/detail-views.css
@@ -1,0 +1,102 @@
+/* All Views */
+.sectionHeading {
+  font-size: 1.25em;
+  margin-top: 1em;
+  margin-bottom: 0.25em;
+}
+
+.previewImg {
+  width: 100%;
+  min-height: 12em;
+  margin-bottom: 1em;
+
+  h3 {
+    text-align: center;
+  }
+}
+
+/*************************/
+/* Summary View */
+
+.atAGlance {
+  font-size: 1.5em;
+  text-align: center;
+  font-style: italic;
+  border-bottom: 1px solid lightgray;
+  margin: 0 1em;
+}
+
+.previewMap {
+  z-index: 4;
+  width: 97%;
+  height: 16em;
+  padding: .2em 0 2em;
+}
+
+.keywords {
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: left;
+  align-content: center;
+}
+
+.keyword {
+  color: white;
+  padding: 0.35em;
+  border-radius: 0.1em 0.4em;
+  margin: 0.25em 0.2em;
+  flex: 0 1 auto;
+}
+
+.infoCircle {
+  position: relative;
+  max-width: 1.1em;
+  max-height: 1.1em;
+  top: .1em;
+  left: .3em;
+}
+
+.star {
+  color: yellow;
+  max-height: 1em;
+  max-width: 1em;
+}
+
+.dsmmInfo {
+  position: relative;
+  display: inline-block;
+i {
+  color: white;
+  margin: 0.5em;
+}
+a {
+  color: $color-visited-light;
+}
+.text {
+  visibility: hidden;
+  opacity: 0;
+  bottom: -0.5em;
+  left: 105%;
+  width: 30em;
+  position: absolute;
+  z-index: 1001;
+  background-color: black;
+  border: solid thin white;
+  border-radius: 6px;
+  padding: 2em;
+  text-align: left;
+}
+&:hover .text {
+   visibility: visible;
+   opacity: 1;
+   transition: opacity 300ms;
+ }
+}
+
+.dsmmMissing {
+  color: grey;
+}
+
+
+/*************************/
+/* Description View */

--- a/client/src/detail/detail-views.css
+++ b/client/src/detail/detail-views.css
@@ -30,7 +30,7 @@
   z-index: 4;
   width: 97%;
   height: 16em;
-  padding: .2em 0 2em;
+  padding-top: 0.25em;
 }
 
 .keywords {
@@ -99,13 +99,13 @@ a {
 
 .showMoreButton {
   text-align: right;
-  /*background-color: #be6a00;*/
+  text-decoration: underline;
 }
 
 .showMoreButton:hover,
 .showMoreButton:focus {
-  /*background-color: color(#be6a00 tint(15%));*/
   cursor: pointer;
+  font-style: italic;
 }
 
 

--- a/client/src/result/collections/CollectionTileComponent.jsx
+++ b/client/src/result/collections/CollectionTileComponent.jsx
@@ -31,7 +31,7 @@ class CollectionTile extends React.Component {
   renderThumbnailMap() {
     if (!this.thumbnailUrl) {
       return <div className={styles.mapContainer}>
-        <MapThumbnailComponent geometry={this.props.geometry}/>
+        <MapThumbnailComponent geometry={this.props.geometry} interactive={false}/>
       </div>
     }
   }

--- a/client/src/result/granules/MapContainer.js
+++ b/client/src/result/granules/MapContainer.js
@@ -2,7 +2,6 @@ import { connect } from 'react-redux'
 import _ from 'lodash'
 import MapComponent from '../../search/map/MapComponent'
 import { toggleGranuleFocus } from '../../actions/FlowActions'
-import { convertEnvelopeToPolygon } from '../../utils/geoUtils'
 
 const mapStateToProps = (state) => {
   let { granules } = state.domain.results
@@ -30,7 +29,7 @@ const MapContainer = connect(
 const convertToGeoJson = (recordData, id) => {
   // Currently defaulting to rendering bounding box coordinates
   return {
-    geometry: convertEnvelopeToPolygon(recordData.spatialBounding),
+    geometry: recordData.spatialBounding,
     properties: _.assign({}, recordData, {id: id}),
     type: "Feature"
   }

--- a/client/src/search/map/MapComponent.jsx
+++ b/client/src/search/map/MapComponent.jsx
@@ -56,7 +56,7 @@ class MapComponent extends React.Component {
         minZoom: 2,
         maxZoom: 5,
         layers: [
-            L.esri.basemapLayer("Oceans"),
+            L.esri.basemapLayer("Imagery"),
             L.esri.basemapLayer("OceansLabels")
         ],
         attributionControl: false

--- a/client/src/utils/geoUtils.js
+++ b/client/src/utils/geoUtils.js
@@ -47,7 +47,7 @@ export const ensureDatelineFriendlyPolygon = (geometry) => {
 }
 
 export const convertNegativeLongitudes = (coordinates) => {
-  const crossesDateline = Math.abs(coordinates[0][0] - coordinates[1][0]) > 180
+  const crossesDateline = coordinates[0][0] > coordinates[1][0]
   return coordinates.map( (pair) =>
     (crossesDateline && pair[0] < 0 && pair[0] > -180) ? [pair[0] + 360, pair[1]] : pair )
 }

--- a/client/src/utils/geoUtils.js
+++ b/client/src/utils/geoUtils.js
@@ -47,7 +47,9 @@ export const ensureDatelineFriendlyPolygon = (geometry) => {
 }
 
 export const convertNegativeLongitudes = (coordinates) => {
-  return coordinates.map((pair) => pair[0] < 0 ? [pair[0] + 360, pair[1]] : pair)
+  const crossesDateline = Math.abs(coordinates[0][0] - coordinates[1][0]) > 180
+  return coordinates.map( (pair) =>
+    (crossesDateline && pair[0] < 0 && pair[0] > -180) ? [pair[0] + 360, pair[1]] : pair )
 }
 
 export const convertBboxToGeoJson = (coordString) => {

--- a/client/src/utils/geoUtils.js
+++ b/client/src/utils/geoUtils.js
@@ -31,25 +31,25 @@ export const recenterGeometry = (geometry) => {
   return _.assign({}, geometry, {coordinates: newCoordinates})
 }
 
-export const convertEnvelopeToPolygon = (geometry) => {
-  if (geometry.type.toLowerCase() !== 'envelope') {
-    return geometry
-  }
-
-  const eCoords = geometry.coordinates
-  const pCoords = [
-    [
-      [eCoords[0][0], eCoords[0][1]],
-      [eCoords[0][0], eCoords[1][1]],
-      [eCoords[1][0], eCoords[1][1]],
-      [eCoords[1][0], eCoords[0][1]]
-    ]
-  ]
-  return {
-    type: "Polygon",
-    coordinates: pCoords
-  }
-}
+// export const convertEnvelopeToPolygon = (geometry) => {
+//   if (geometry.type.toLowerCase() !== 'envelope') {
+//     return geometry
+//   }
+//
+//   const eCoords = geometry.coordinates
+//   const pCoords = [
+//     [
+//       [eCoords[0][0], eCoords[0][1]],
+//       [eCoords[0][0], eCoords[1][1]],
+//       [eCoords[1][0], eCoords[1][1]],
+//       [eCoords[1][0], eCoords[0][1]]
+//     ]
+//   ]
+//   return {
+//     type: "Polygon",
+//     coordinates: pCoords
+//   }
+// }
 
 export const convertBboxToGeoJson = (coordString) => {
   const coordArray = coordString.split(',').map(x => parseFloat(x))

--- a/client/src/utils/geoUtils.js
+++ b/client/src/utils/geoUtils.js
@@ -31,17 +31,23 @@ export const recenterGeometry = (geometry) => {
   return _.assign({}, geometry, {coordinates: newCoordinates})
 }
 
-export const ensurePolygon = (geometry) => {
-  if (geometry.type.toLowerCase() === 'polygon') {
-    return geometry
+export const ensureDatelineFriendlyPolygon = (geometry) => {
+  let coords
+  if (geometry.type.toLowerCase() === 'point') {
+    coords = Array(5).fill(geometry.coordinates)
   }
-
-  const point = geometry.coordinates
-  const polyCoords = [Array(5).fill(point)]
+  else {
+    coords = geometry.coordinates[0]
+  }
   return {
     type: 'Polygon',
-    coordinates: polyCoords
+    coordinates: [convertNegativeLongitudes(coords)]
   }
+
+}
+
+export const convertNegativeLongitudes = (coordinates) => {
+  return coordinates.map((pair) => pair[0] < 0 ? [pair[0] + 360, pair[1]] : pair)
 }
 
 export const convertBboxToGeoJson = (coordString) => {

--- a/client/src/utils/geoUtils.js
+++ b/client/src/utils/geoUtils.js
@@ -31,25 +31,18 @@ export const recenterGeometry = (geometry) => {
   return _.assign({}, geometry, {coordinates: newCoordinates})
 }
 
-// export const convertEnvelopeToPolygon = (geometry) => {
-//   if (geometry.type.toLowerCase() !== 'envelope') {
-//     return geometry
-//   }
-//
-//   const eCoords = geometry.coordinates
-//   const pCoords = [
-//     [
-//       [eCoords[0][0], eCoords[0][1]],
-//       [eCoords[0][0], eCoords[1][1]],
-//       [eCoords[1][0], eCoords[1][1]],
-//       [eCoords[1][0], eCoords[0][1]]
-//     ]
-//   ]
-//   return {
-//     type: "Polygon",
-//     coordinates: pCoords
-//   }
-// }
+export const ensurePolygon = (geometry) => {
+  if (geometry.type.toLowerCase() === 'polygon') {
+    return geometry
+  }
+
+  const point = geometry.coordinates
+  const polyCoords = [Array(5).fill(point)]
+  return {
+    type: 'Polygon',
+    coordinates: polyCoords
+  }
+}
 
 export const convertBboxToGeoJson = (coordString) => {
   const coordArray = coordString.split(',').map(x => parseFloat(x))


### PR DESCRIPTION
Closes #255. 

Summary of changes:
- Created a summary view component to reside within the detail view component. We may want to rename these later so it's clearly the collection view. This is the first step in having a future tab bar to swap out the view of the collection.
- Made MapThumbnailComponent support interactive use (stays not-interactive on results grid view but can be zoomed/panned in collection summary view)
- Changed base map of all maps to satellite imagery (thought it looked nicer!)
- Fixed bug #273 
- Fixed bug #274 
- Made the title expandable so users can actually read the whole thing

I didn't try to change the style of the modal here, but rather focused on just the content and functionality of the summary view. It made sense to me that we'd put our heads together on style once all views are complete. 

Since we're planning to quickly continue on the other views of the collection, I also didn't leave in anything that technically belongs in other views (i.e., description, thumbnail image, access links).