### PR TITLE
#281 - Fixed categories collapsing unexpectedly. In short, we can't g…

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -5125,6 +5125,12 @@
         "toposort": "https://registry.npmjs.org/toposort/-/toposort-1.0.6.tgz"
       }
     },
+    "html-webpack-template": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/html-webpack-template/-/html-webpack-template-5.6.0.tgz",
+      "integrity": "sha1-bNuWtoDr0qYzyGm3pqtBOqKpEhg=",
+      "dev": true
+    },
     "htmlparser2": {
       "version": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
       "integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",

--- a/client/src/filter/FacetFilter.jsx
+++ b/client/src/filter/FacetFilter.jsx
@@ -150,7 +150,7 @@ export default class FacetFilter extends Component {
 		let expandableCategories = [];
 		const categories = Object.keys(this.props.facetMap);
 
-		categories.forEach((category, categoryIndex) => {
+		categories.forEach(category => {
 			// show hamburger menu for high-level categories
 			const highLevelHeading = <span>&#9776;&nbsp;{category}</span>;
 
@@ -159,7 +159,7 @@ export default class FacetFilter extends Component {
 				this.props.facetMap[category],
 			);
 
-			const expandableKey = `${categoryIndex}-${category}`;
+			const expandableKey = `${category}`;
 
 			// high-level categories (e.g. - "Data Themes" | "Platforms" | "Projects" | "Data Centers" | "Data Resolution")
 			expandableCategories.push(

--- a/client/src/filter/Filters.jsx
+++ b/client/src/filter/Filters.jsx
@@ -37,14 +37,17 @@ class Filters extends Component {
 		this.filters = [
 			// TODO: reintroduce these filters when we officially move them from the top menu search component
 			// {
+			//  name: "map",
 			// 	heading: <FilterHeading icon={mapFilterIcon} text="Map Filter" />,
 			// 	content: <MapFilter />,
 			// },
 			// {
+			//  name: "time",
 			// 	heading: <FilterHeading icon={timeFilterIcon} text="Time Filter" />,
 			// 	content: <TimeFilter />,
 			// },
 			{
+				name: "keywords",
 				heading: <FilterHeading icon={facetFilterIcon} text="Keywords" />,
 				content: <FacetFilterContainer
 					submit={props.submit}
@@ -76,7 +79,7 @@ class Filters extends Component {
                     <Expandable
                         key={index}
                         value={index}
-                        open={index === this.state.openIndex}
+                        open={index === this.state.openIndex || filter.name === "keywords"} /* force keywords open */
                         onToggle={this.handleFilterToggle}
                         heading={filter.heading}
                         styleHeading={styleFilterHeadings}


### PR DESCRIPTION
…uarantee the order in which a forEach will iterate over categories on subsequent renders from a search. Thus, an index mismatch between renders was causing a miss when looking for our saved "openExpandables" state. Because the categories are already unique keys we can simply remove the index from the expandable key to ensure it is consistent between renders. Also added logic to force the "Keywords" section of the filter menu open at all times.

resolves #281 