### PR TITLE
Include build date on info endpoint.

### DIFF
--- a/api-search/src/main/resources/application.yml
+++ b/api-search/src/main/resources/application.yml
@@ -79,3 +79,4 @@ search:
     _all: 1
 
 info.version: ${version}
+info.buildDate: ${buildDate}

--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,7 @@ group = 'org.cedar.onestop'
 subprojects.each {
   it.group = group
   it.version = version
+  it.ext.buildDate = "${new Date().format("YYYY-MM-dd", TimeZone.getTimeZone('UTC'))}"
 }
 
 buildScan {


### PR DESCRIPTION
- version info is automatically updated as long as nothing in the deployment overwrites the value later. (no change needed)
- added buildDate to the info endpoint

Test response from the info endpoint now looks like:
{version: "2.0.0-SNAPSHOT", buildDate: "2017-10-27"}

resolves #230