### PR TITLE
Actually resolves #230 for the 1.3 milestone.

### DIFF
--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -92,3 +92,4 @@ search:
     _all: 1
 
 info.version: ${version}
+info.buildDate: ${buildDate}

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ group = 'cires.ncei.onestop'
 subprojects.each {
   it.group = group
   it.version = version
+  it.ext.buildDate = "${new Date().format("YYYY-MM-dd", TimeZone.getTimeZone('UTC'))}"
 }
 
 buildScan {


### PR DESCRIPTION
See also review #289 for the 2.0 milestone.

Verified that a clean build the info endpoint returns `{"version":"1.2.1-SNAPSHOT","buildDate":"2017-10-30"}`, and that these values are correctly built into application.yml inside the war.