### PR TITLE
#279 - upgraded owasp dep checker, added two suppressions (CVE-2013-4…

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -18,6 +18,10 @@ repositories {
   }
 }
 
+configurations {
+  compile.exclude module: 'tomcat-annotations-api', group: 'org.apache.tomcat'
+}
+
 dependencies {
   compile 'org.codehaus.groovy:groovy:2.4.10'
   compile 'org.codehaus.groovy:groovy-json:2.4.10'
@@ -42,7 +46,7 @@ dependencies {
   compile (group: 'ch.qos.logback', name: 'logback-core', version: '1.2.3')
   compile ('org.springframework.boot:spring-boot-starter-actuator')
   compile ('org.springframework.cloud:spring-cloud-context:1.1.7.RELEASE')
-  compile 'com.github.fge:json-schema-validator:2.2.6'
+  compile 'com.github.java-json-tools:json-schema-validator:2.2.8'
   compile 'org.apache.commons:commons-lang3:3.4'
   compile 'com.spatial4j:spatial4j:0.5' // Necessary for embedded ES to have geo_shape type available
   compile 'com.vividsolutions:jts:1.13' // Necessary for embedded ES to have geo_shape type available

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   ext {
-    springBootVersion = '1.5.1.RELEASE'
+    springBootVersion = '1.5.8.RELEASE'
   }
   repositories {
     maven {
@@ -14,7 +14,7 @@ buildscript {
     classpath "org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}"
     classpath 'com.wiredforcode:gradle-spawn-plugin:0.6.0'
     classpath 'com.moowork.gradle:gradle-node-plugin:0.13'
-    classpath 'org.owasp:dependency-check-gradle:1.4.5'
+    classpath 'org.owasp:dependency-check-gradle:2.1.1'
   }
 }
 
@@ -31,6 +31,7 @@ subprojects {
 //      project.tasks.findByName('check').dependsOn('dependencyCheck')
 
       dependencyCheck {
+        skipConfigurations = ["providedRuntime"]
         suppressionFile = "${rootDir}/owasp-suppressions.xml"
         failBuildOnCVSS = 4
 

--- a/owasp-suppressions.xml
+++ b/owasp-suppressions.xml
@@ -27,4 +27,20 @@
     <gav regex="true">^org\.springframework\.cloud:spring-cloud-context:.*$</gav>
     <cve>CVE-2016-9878</cve>
   </suppress>
+
+  <suppress>
+    <notes><![CDATA[
+   file name: validation-api-1.1.0.Final.jar
+   ]]></notes>
+    <gav regex="true">^javax\.validation:validation-api:.*$</gav>
+    <cve>CVE-2013-4499</cve>
+  </suppress>
+
+  <suppress>
+    <notes><![CDATA[
+   file name: mailapi-1.4.3.jar
+   ]]></notes>
+    <gav regex="true">^javax\.mail:mailapi:.*$</gav>
+    <cpe>cpe:/a:mail_project:mail</cpe>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
…499 for validation-api, and mailapi for json schema validator), explicitly remove tomcat-annotation-api for security vulnerability (not needed), upgrade json-schema-validator to new repo and version

for 1x: resolves #279 