### PR TITLE
383 ui granule protocols

### DIFF
--- a/client/src/detail/GranuleTab/GranuleView.jsx
+++ b/client/src/detail/GranuleTab/GranuleView.jsx
@@ -6,6 +6,7 @@ import Button from '../../common/input/Button'
 import _ from 'lodash'
 import GranuleMapContainer from './GranuleMapContainer'
 import A from '../../common/link/Link'
+import {identifyProtocol} from '../../utils/ProtocolUtils'
 
 const styleLegendHeading = {
   margin: '0 0 0.618em 0',
@@ -75,51 +76,13 @@ const styleLegendLabel = {
 }
 
 export default class GranuleView extends Component {
-  constructor(props) {
-    super(props)
-
-    this.protocols = [
-      {
-        id: 'C',
-        names: [ 'ogc:wcs' ],
-        color: 'coral',
-        label: 'OGC Web Coverage Service',
-      },
-      {id: 'D', names: [ 'download' ], color: 'blue', label: 'Download'},
-      {id: 'F', names: [ 'ftp' ], color: 'red', label: 'FTP'},
-      {
-        id: 'H',
-        names: [ 'http', 'https' ],
-        color: 'purple',
-        label: 'HTTP/HTTPS',
-      },
-      {
-        id: 'L',
-        names: [ 'noaa:las' ],
-        color: 'aqua',
-        label: 'NOAA Live Access Server',
-      },
-      {
-        id: 'M',
-        names: [ 'ogc:wms' ],
-        color: 'goldenrod',
-        label: 'OGC Web Map Service',
-      },
-      {id: 'O', names: [ 'opendap' ], color: 'green', label: 'OPeNDAP'},
-      {id: 'T', names: [ 'thredds' ], color: 'grey', label: 'THREDDS'},
-      {id: 'W', names: [ '' ], color: '#e69500', label: 'Web'},
-    ]
-  }
-
   render() {
     const {results, toggleFocus} = this.props
     const usedProtocols = new Set()
     let rowNumber = -1
     const tableRows = _.map(results, (value, key) => {
       const rowEven = rowNumber++ % 2 === 0
-      _.forEach(value.links, link =>
-        usedProtocols.add(this.identifyProtocol(link))
-      )
+      _.forEach(value.links, link => usedProtocols.add(identifyProtocol(link)))
       return (
         <GranuleViewTableRow
           key={key}
@@ -199,7 +162,7 @@ export default class GranuleView extends Component {
 
   renderBadges(links) {
     const badges = _.chain(links)
-      .map(link => ({protocol: this.identifyProtocol(link), url: link.linkUrl}))
+      .map(link => ({protocol: identifyProtocol(link), url: link.linkUrl}))
       .filter(info => info.protocol)
       .sortBy(info => info.protocol.id)
       .map(this.renderBadge.bind(this))
@@ -223,11 +186,6 @@ export default class GranuleView extends Component {
         {protocol.id}
       </A>
     )
-  }
-
-  identifyProtocol(link) {
-    const name = _.toLower(link.linkProtocol || '')
-    return _.find(this.protocols, p => p.names.includes(name))
   }
 
   renderPaginationButton() {

--- a/client/src/utils/ProtocolUtils.js
+++ b/client/src/utils/ProtocolUtils.js
@@ -1,0 +1,39 @@
+import _ from 'lodash'
+import Immutable from 'seamless-immutable'
+
+const protocols = Immutable([
+  {
+    id: 'C',
+    names: [ 'ogc:wcs' ],
+    color: 'coral',
+    label: 'OGC Web Coverage Service',
+  },
+  {id: 'D', names: [ 'download' ], color: 'blue', label: 'Download'},
+  {id: 'F', names: [ 'ftp' ], color: 'red', label: 'FTP'},
+  {
+    id: 'H',
+    names: [ 'http', 'https' ],
+    color: 'purple',
+    label: 'HTTP/HTTPS',
+  },
+  {
+    id: 'L',
+    names: [ 'noaa:las' ],
+    color: 'aqua',
+    label: 'NOAA Live Access Server',
+  },
+  {
+    id: 'M',
+    names: [ 'ogc:wms' ],
+    color: 'goldenrod',
+    label: 'OGC Web Map Service',
+  },
+  {id: 'O', names: [ 'opendap' ], color: 'green', label: 'OPeNDAP'},
+  {id: 'T', names: [ 'thredds' ], color: 'grey', label: 'THREDDS'},
+  {id: 'W', names: [ '' ], color: '#e69500', label: 'Web'},
+])
+
+export const identifyProtocol = link => {
+  const name = _.toLower(link.linkProtocol || '')
+  return _.find(protocols, p => p.names.includes(name))
+}

--- a/client/src/utils/ProtocolUtils.js
+++ b/client/src/utils/ProtocolUtils.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 import Immutable from 'seamless-immutable'
 
-const protocols = Immutable([
+export const protocols = Immutable([
   {
     id: 'C',
     names: [ 'ogc:wcs' ],

--- a/client/src/utils/ProtocolUtils.js
+++ b/client/src/utils/ProtocolUtils.js
@@ -28,8 +28,18 @@ export const protocols = Immutable([
     color: 'goldenrod',
     label: 'OGC Web Map Service',
   },
-  {id: 'O', names: [ 'opendap' ], color: 'green', label: 'OPeNDAP'},
-  {id: 'T', names: [ 'thredds' ], color: 'grey', label: 'THREDDS'},
+  {
+    id: 'O',
+    names: [ 'opendap', 'opendap:opendap', 'opendap:hyrax' ],
+    color: 'green',
+    label: 'OPeNDAP',
+  },
+  {
+    id: 'T',
+    names: [ 'thredds', 'unidata:thredds' ],
+    color: 'grey',
+    label: 'THREDDS',
+  },
   {id: 'W', names: [ '' ], color: '#e69500', label: 'Web'},
 ])
 

--- a/client/test/utils/protocolUtilsSpec.js
+++ b/client/test/utils/protocolUtilsSpec.js
@@ -1,6 +1,6 @@
 import '../specHelper'
 import { expect, assert } from 'chai'
-import * as protocolUtils from '../../src/utils/protocolUtils'
+import * as protocolUtils from '../../src/utils/ProtocolUtils'
 import _ from 'lodash'
 
 describe('The protocolUtils', function () {

--- a/client/test/utils/protocolUtilsSpec.js
+++ b/client/test/utils/protocolUtilsSpec.js
@@ -106,6 +106,8 @@ describe('The protocolUtils', function () {
       {linkProtocol: 'opendap'},
       {linkProtocol: 'OPENDAP'},
       {linkProtocol: 'OPeNDAP'},
+      {linkProtocol: 'OPeNDAP:OPeNDAP'},
+      {linkProtocol: 'OPeNDAP:Hyrax'},
     ]
 
     _.each(testCases, (p) => {
@@ -120,6 +122,7 @@ describe('The protocolUtils', function () {
     const testCases = [
       {linkProtocol: 'thredds'},
       {linkProtocol: 'THREDDS'},
+      {linkProtocol: 'UNIDATA:THREDDS'},
     ]
 
     _.each(testCases, (p) => {

--- a/client/test/utils/protocolUtilsSpec.js
+++ b/client/test/utils/protocolUtilsSpec.js
@@ -1,9 +1,16 @@
 import '../specHelper'
-import { expect } from 'chai'
+import { expect, assert } from 'chai'
 import * as protocolUtils from '../../src/utils/protocolUtils'
 import _ from 'lodash'
 
 describe('The protocolUtils', function () {
+
+  it('has distinct id and color combinations for each protocol', function() {
+    const protocolIdCombos = _.map(protocolUtils.protocols, p => {
+      return `${p.id}-${p.color}`
+    })
+    assert.deepEqual(protocolIdCombos, _.uniq(protocolIdCombos), `${protocolIdCombos} vs ${_.uniq(protocolIdCombos)}`)
+  })
 
   it('can identify ogc:wcs', function () {
     const testCases = [
@@ -17,7 +24,7 @@ describe('The protocolUtils', function () {
       const protocol = protocolUtils.identifyProtocol(p)
       protocol.id.should.equal('C')
       protocol.label.should.equal('OGC Web Coverage Service')
-      // TODO worth confirming color?
+      protocol.color.should.equal('coral')
     })
   })
 
@@ -32,7 +39,7 @@ describe('The protocolUtils', function () {
       const protocol = protocolUtils.identifyProtocol(p)
       protocol.id.should.equal('D')
       protocol.label.should.equal('Download')
-      // TODO worth confirming color?
+      protocol.color.should.equal('blue')
     })
   })
 
@@ -46,7 +53,7 @@ describe('The protocolUtils', function () {
       const protocol = protocolUtils.identifyProtocol(p)
       protocol.id.should.equal('F')
       protocol.label.should.equal('FTP')
-      // TODO worth confirming color?
+      protocol.color.should.equal('red')
     })
   })
 
@@ -62,7 +69,7 @@ describe('The protocolUtils', function () {
       const protocol = protocolUtils.identifyProtocol(p)
       protocol.id.should.equal('H')
       protocol.label.should.equal('HTTP/HTTPS')
-      // TODO worth confirming color?
+      protocol.color.should.equal('purple')
     })
   })
 
@@ -76,7 +83,7 @@ describe('The protocolUtils', function () {
       const protocol = protocolUtils.identifyProtocol(p)
       protocol.id.should.equal('L')
       protocol.label.should.equal('NOAA Live Access Server')
-      // TODO worth confirming color?
+      protocol.color.should.equal('aqua')
     })
   })
 
@@ -90,7 +97,7 @@ describe('The protocolUtils', function () {
       const protocol = protocolUtils.identifyProtocol(p)
       protocol.id.should.equal('M')
       protocol.label.should.equal('OGC Web Map Service')
-      // TODO worth confirming color?
+      protocol.color.should.equal('goldenrod')
     })
   })
 
@@ -105,7 +112,7 @@ describe('The protocolUtils', function () {
       const protocol = protocolUtils.identifyProtocol(p)
       protocol.id.should.equal('O')
       protocol.label.should.equal('OPeNDAP')
-      // TODO worth confirming color?
+      protocol.color.should.equal('green')
     })
   })
 
@@ -119,7 +126,7 @@ describe('The protocolUtils', function () {
       const protocol = protocolUtils.identifyProtocol(p)
       protocol.id.should.equal('T')
       protocol.label.should.equal('THREDDS')
-      // TODO worth confirming color?
+      protocol.color.should.equal('grey')
     })
   })
 
@@ -132,7 +139,7 @@ describe('The protocolUtils', function () {
       const protocol = protocolUtils.identifyProtocol(p)
       protocol.id.should.equal('W')
       protocol.label.should.equal('Web')
-      // TODO worth confirming color?
+      protocol.color.should.equal('#e69500')
     })
   })
 

--- a/client/test/utils/protocolUtilsSpec.js
+++ b/client/test/utils/protocolUtilsSpec.js
@@ -1,0 +1,153 @@
+import '../specHelper'
+import { expect } from 'chai'
+import * as protocolUtils from '../../src/utils/protocolUtils'
+import _ from 'lodash'
+
+describe('The protocolUtils', function () {
+
+  it('can identify ogc:wcs', function () {
+    const testCases = [
+      {linkProtocol: 'ogc:wcs'},
+      {linkProtocol: 'OGC:wcs'},
+      {linkProtocol: 'ogc:WCS'},
+      {linkProtocol: 'OGC:WCS'},
+    ]
+
+    _.each(testCases, (p) => {
+      const protocol = protocolUtils.identifyProtocol(p)
+      protocol.id.should.equal('C')
+      protocol.label.should.equal('OGC Web Coverage Service')
+      // TODO worth confirming color?
+    })
+  })
+
+  it('can identify download links', function () {
+    const testCases = [
+      {linkProtocol: 'download'},
+      {linkProtocol: 'Download'},
+      {linkProtocol: 'DOWNLOAD'},
+    ]
+
+    _.each(testCases, (p) => {
+      const protocol = protocolUtils.identifyProtocol(p)
+      protocol.id.should.equal('D')
+      protocol.label.should.equal('Download')
+      // TODO worth confirming color?
+    })
+  })
+
+  it('can identify FTP links', function () {
+    const testCases = [
+      {linkProtocol: 'FTP'},
+      {linkProtocol: 'ftp'},
+    ]
+
+    _.each(testCases, (p) => {
+      const protocol = protocolUtils.identifyProtocol(p)
+      protocol.id.should.equal('F')
+      protocol.label.should.equal('FTP')
+      // TODO worth confirming color?
+    })
+  })
+
+  it('can identify http links', function () {
+    const testCases = [
+      {linkProtocol: 'HTTP'},
+      {linkProtocol: 'HTTPS'},
+      {linkProtocol: 'http'},
+      {linkProtocol: 'https'},
+    ]
+
+    _.each(testCases, (p) => {
+      const protocol = protocolUtils.identifyProtocol(p)
+      protocol.id.should.equal('H')
+      protocol.label.should.equal('HTTP/HTTPS')
+      // TODO worth confirming color?
+    })
+  })
+
+  it('can identify noaa:las', function () {
+    const testCases = [
+      {linkProtocol: 'noaa:las'},
+      {linkProtocol: 'NOAA:LAS'},
+    ]
+
+    _.each(testCases, (p) => {
+      const protocol = protocolUtils.identifyProtocol(p)
+      protocol.id.should.equal('L')
+      protocol.label.should.equal('NOAA Live Access Server')
+      // TODO worth confirming color?
+    })
+  })
+
+  it('can identify ogc:wms', function () {
+    const testCases = [
+      {linkProtocol: 'ogc:wms'},
+      {linkProtocol: 'OGC:WMS'},
+    ]
+
+    _.each(testCases, (p) => {
+      const protocol = protocolUtils.identifyProtocol(p)
+      protocol.id.should.equal('M')
+      protocol.label.should.equal('OGC Web Map Service')
+      // TODO worth confirming color?
+    })
+  })
+
+  it('can identify opendap', function () {
+    const testCases = [
+      {linkProtocol: 'opendap'},
+      {linkProtocol: 'OPENDAP'},
+      {linkProtocol: 'OPeNDAP'},
+    ]
+
+    _.each(testCases, (p) => {
+      const protocol = protocolUtils.identifyProtocol(p)
+      protocol.id.should.equal('O')
+      protocol.label.should.equal('OPeNDAP')
+      // TODO worth confirming color?
+    })
+  })
+
+  it('can identify thredds', function () {
+    const testCases = [
+      {linkProtocol: 'thredds'},
+      {linkProtocol: 'THREDDS'},
+    ]
+
+    _.each(testCases, (p) => {
+      const protocol = protocolUtils.identifyProtocol(p)
+      protocol.id.should.equal('T')
+      protocol.label.should.equal('THREDDS')
+      // TODO worth confirming color?
+    })
+  })
+
+  it('can identify empty protocols', function () {
+    const testCases = [
+      {linkProtocol: ''},
+    ]
+
+    _.each(testCases, (p) => {
+      const protocol = protocolUtils.identifyProtocol(p)
+      protocol.id.should.equal('W')
+      protocol.label.should.equal('Web')
+      // TODO worth confirming color?
+    })
+  })
+
+  it('cannot default unknown protocols', function () {
+    const testCases = [
+      {linkProtocol: 'nonsense'},
+      {linkProtocol: ' '},
+      {linkProtocol: 'download typo'},
+      {linkProtocol: 'etc'},
+    ]
+
+    _.each(testCases, (p) => {
+      const protocol = protocolUtils.identifyProtocol(p)
+      expect(protocol).to.be.undefined
+    })
+  })
+
+})


### PR DESCRIPTION
Closes #383.

- [x] Refactors out a util to facilitate testing
- [x] Adds more protocol specifications into the OPeNDAP and THREDDS badges

A question for this review: Based on the spreadsheet, there's some interpretation that the labels should be distinct.
OPeNDAP:OPeNDAP -> OPeNDAP root URL
OPeNDAP:Hyrax -> OPeNDAP Hyrax server
UNIDATA:THREDDS ->THREDDS Catalog

I interpreted the task to mean we should continue to bucket them into less specific labels, since the badges are just indicators. I also assumed that the additional protocols were too uncertain to add yet. (Also, if we add too many protocols, we're going to run into difficulty having enough distinct colors).