### PR TITLE
Retire.js suppressions file.

### DIFF
--- a/client/.retireignore.json
+++ b/client/.retireignore.json
@@ -1,0 +1,22 @@
+[
+    {
+      "component": "aComponentExample",
+      "identifiers": { "issue": "issueNumber"},
+      "version": "0.0.1",
+      "path": "path of dependency",
+      "justification": "We don't expect this vulnerability"
+    },
+    {
+      "path": "node_modules/npm-check-updates",
+      "justification": "Development dependency: Not packaged in production code."
+    },
+    {
+      "path": "node_modules/npmi",
+      "justification": "Development dependency: Not packaged in production code."
+    },
+    {
+      "path": "node_modules/npm",
+      "version": "6.1.0",
+      "justification": "Prototype pollution attacks don't affect this project. We do not run server-side JS."
+    }
+]


### PR DESCRIPTION
Adding retire.js suppressions file to client to eliminate false positives from npm being reported when running retire -p.