### PR TITLE
Add help message with regex search information.

### DIFF
--- a/client/src/common/info/Help.jsx
+++ b/client/src/common/info/Help.jsx
@@ -179,6 +179,23 @@ export default class Help extends React.Component {
                 </li>
               </ul>
             </li>
+
+            <li>
+              Metadata can also be searched by using a regex. Regex terms can be
+              written using two different methods. The easiest method is to use
+              double quotes to capture the regex along with the reserved characters
+              literally. Regex terms must be enclosed with forward slashes.
+              Regex terms not enclosed with double quotes must have every reserved
+              character escaped by a backslash.
+              <ul style={styleExamples}>
+                <li style={styleExamplesListItem}>"/^GHRSST"</li>
+                <li style={styleExamplesListItem}>"/^GHRSST.*(Version 2)$"</li>
+              </ul>
+              <ul style={styleExamples}>
+                <li style={styleExamplesListItem}>\/\^GHRSST</li>
+                <li style={styleExamplesListItem}>\/\^GHRSST\.\*(Version 2)\$\/</li>
+              </ul>
+            </li>
           </ul>
 
           <hr style={styleHR} />


### PR DESCRIPTION
After running through story 278 which I closed as a won't fix, I found that we can use regex queries with query_string but there is no way to help the user by validating input and giving a context message like we do with empty search fields or queries that start with * or ?. The main problem is that Elastic Search can handle so many of the reserved characters that to validate search entries at the client level would be problematic.

So I added information to the help page for using a regex with the search field.