### PR TITLE
Enable CORS for api-search endpoints. Will apply to localhost and dev…

### DIFF
--- a/client/docker/nginx.conf
+++ b/client/docker/nginx.conf
@@ -37,6 +37,16 @@ server {
   }
 
   location /onestop/api {
+    if ($request_method ~* "(GET|POST)") {
+      add_header "Access-Control-Allow-Origin"  *;
+    }
+    if ($request_method = OPTIONS ) {
+      add_header "Access-Control-Allow-Origin"  *;
+      add_header "Access-Control-Allow-Methods" "GET, POST, OPTIONS, HEAD";
+      add_header "Access-Control-Allow-Headers" "Authorization, Origin, X-Requested-With, Content-Type, Accept";
+      return 200;
+    }
+
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_pass http://onestop_api/onestop/api;


### PR DESCRIPTION
… server.

Resolves maintenance board issue 64.

# Security Note

A resource that is publicly accessible, with no access control checks, can always safely return an Access-Control-Allow-Origin header whose value is “*”.
(from https://www.w3.org/TR/cors/)

Because everything provided by api-search is designed to be open, unrestricted data (no data on these endpoints is considered sensitive) and have read-only access, there is no security risk to opening CORS freely.

It is possible to change our configuration to enable CORS only on specific, approved endpoints. If our API changes to include endpoints that have restricted information or the ability to make changes, we can lock the configuration down more tightly.

# To test:

Create an html file with the following, and open it using the browser console to see results. When CORS is disabled, all fetch requests fail due to lack of CORS headers.

```<html>
<body>
   <script>

   console.log("Testing 1 2 3...")

   fetch("http://localhost:30000/onestop/api/collection").then(function(response) {
     console.log("collection count:", response.text())
   })

  fetch("http://localhost:30000/onestop/api/collection/AWVjIFGxjKx4_WU3UamE").then(function(response) {
    console.log("collection (detail)", response.text())
  })


  fetch("http://localhost:30000/onestop/api/search/collection", {
        method: 'POST',
        headers: {
          Accept: 'application/json',
          'Content-Type': 'application/json',
        },
        body: '{}',
      }).then(function(response) {
    console.log("collection search", response.text())
  })


   fetch("http://localhost:30000/onestop/api/granule").then(function(response) {
     console.log("granule count", response.text())
   })

  fetch("http://localhost:30000/onestop/api/granule/AWVjIHnSjKx4_WU3UaoB").then(function(response) {
    console.log("granule (detail)", response.text())
  })

 fetch("http://localhost:30000/onestop/api/granule/ABC").then(function(response) {
   console.log("granule 404", response.text())
 })


  fetch("http://localhost:30000/onestop/api/search/granule", {
        method: 'POST',
        headers: {
          Accept: 'application/json',
          'Content-Type': 'application/json',
        },
        body: '{}',
      }).then(function(response) {
    console.log("granule search", response.text())
  })



   fetch("http://localhost:30000/onestop/api/uiConfig").then(function(response) {
     console.log("fetched uiconfig!", response.text())
   })
    </script>
</body>
</html>
```