### PR TITLE
769  nonce

### DIFF
--- a/api-search/build.gradle
+++ b/api-search/build.gradle
@@ -80,6 +80,7 @@ ext {
     envVars.LOGIN_GOV_CLIENT_ID = "urn:gov:gsa:openidconnect.profiles:sp:sso:NOAA:onestop_api_search_localhost_8080"
     envVars.LOGIN_GOV_ALLOWED_ORIGIN = "http://localhost:8080"
     envVars.LOGIN_GOV_LOGIN_SUCCESS_REDIRECT = "http://localhost:8080/onestop"
+    envVars.LOGIN_GOV_LOGIN_FAILURE_REDIRECT = "http://localhost:8080/onestop"
     envVars.LOGIN_GOV_LOGOUT_SUCCESS_REDIRECT = "http://localhost:8080/onestop"
   }
   else {
@@ -88,6 +89,7 @@ ext {
     envVars.LOGIN_GOV_CLIENT_ID = "urn:gov:gsa:openidconnect.profiles:sp:sso:NOAA:onestop_api_search_localhost_8097"
     envVars.LOGIN_GOV_ALLOWED_ORIGIN = "http://localhost:8097"
     envVars.LOGIN_GOV_LOGIN_SUCCESS_REDIRECT = "http://localhost:8097/onestop/api/login_profile"
+    envVars.LOGIN_GOV_LOGIN_FAILURE_REDIRECT = "http://localhost:8097/onestop/api/login_profile?failure=true"
     envVars.LOGIN_GOV_LOGOUT_SUCCESS_REDIRECT = "http://localhost:8097/onestop/api/login_profile"
   }
   

--- a/api-search/src/main/groovy/org/cedar/onestop/api/search/security/config/LoginGovAuthorizationRequestResolver.groovy
+++ b/api-search/src/main/groovy/org/cedar/onestop/api/search/security/config/LoginGovAuthorizationRequestResolver.groovy
@@ -1,6 +1,5 @@
 package org.cedar.onestop.api.search.security.config
 
-import org.apache.commons.lang3.RandomStringUtils
 import org.cedar.onestop.api.search.security.constants.LoginGovConstants
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
 import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver
@@ -33,7 +32,7 @@ class LoginGovAuthorizationRequestResolver implements OAuth2AuthorizationRequest
             return null
         }
         else {
-            return customAuthorizationRequest(authorizationRequest)
+            return customAuthorizationRequest(authorizationRequest, request.session.id)
         }
     }
 
@@ -44,19 +43,17 @@ class LoginGovAuthorizationRequestResolver implements OAuth2AuthorizationRequest
             return null
         }
         else {
-            return customAuthorizationRequest(authorizationRequest)
+            return customAuthorizationRequest(authorizationRequest, request.session.id)
         }
     }
 
-    OAuth2AuthorizationRequest customAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest) {
+    OAuth2AuthorizationRequest customAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, String sessionId ) {
         String registrationId = resolveRegistrationId(authorizationRequest)
         LinkedHashMap additionalParameters = new LinkedHashMap(authorizationRequest.additionalParameters)
-
         // set login.gov specific params
         // https://developers.login.gov/oidc/#authorization
         if(registrationId == LoginGovConstants.LOGIN_GOV_REGISTRATION_ID) {
-            String charset = (('a'..'z') + ('A'..'Z') + ('0'..'9')).join()
-            String nonce = RandomStringUtils.random(32, charset.toCharArray())
+            String nonce = NonceUtil.generateNonce(sessionId)
             additionalParameters.put("acr_values", LoginGovConstants.LOGIN_GOV_LOA1)
             additionalParameters.put("nonce", nonce)
         }

--- a/api-search/src/main/groovy/org/cedar/onestop/api/search/security/config/LoginGovAuthorizationRequestResolver.groovy
+++ b/api-search/src/main/groovy/org/cedar/onestop/api/search/security/config/LoginGovAuthorizationRequestResolver.groovy
@@ -1,5 +1,6 @@
 package org.cedar.onestop.api.search.security.config
 
+import org.apache.commons.lang3.RandomStringUtils
 import org.cedar.onestop.api.search.security.constants.LoginGovConstants
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
 import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver
@@ -54,8 +55,10 @@ class LoginGovAuthorizationRequestResolver implements OAuth2AuthorizationRequest
         // set login.gov specific params
         // https://developers.login.gov/oidc/#authorization
         if(registrationId == LoginGovConstants.LOGIN_GOV_REGISTRATION_ID) {
+            String charset = (('a'..'z') + ('A'..'Z') + ('0'..'9')).join()
+            String nonce = RandomStringUtils.random(32, charset.toCharArray())
             additionalParameters.put("acr_values", LoginGovConstants.LOGIN_GOV_LOA1)
-            additionalParameters.put("nonce", "1234567890abcdefghijklmnopqrstuvwxyz")
+            additionalParameters.put("nonce", nonce)
         }
 
         return OAuth2AuthorizationRequest

--- a/api-search/src/main/groovy/org/cedar/onestop/api/search/security/config/LoginGovConfiguration.groovy
+++ b/api-search/src/main/groovy/org/cedar/onestop/api/search/security/config/LoginGovConfiguration.groovy
@@ -17,5 +17,6 @@ class LoginGovConfiguration {
     Keystore keystore
     String allowedOrigin
     String loginSuccessRedirect
+    String loginFailureRedirect
     String logoutSuccessRedirect
 }

--- a/api-search/src/main/groovy/org/cedar/onestop/api/search/security/config/NonceUtil.groovy
+++ b/api-search/src/main/groovy/org/cedar/onestop/api/search/security/config/NonceUtil.groovy
@@ -1,0 +1,27 @@
+package org.cedar.onestop.api.search.security.config
+
+import groovy.json.JsonSlurper
+import org.apache.commons.codec.binary.Base64
+import org.apache.commons.lang3.RandomStringUtils
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken
+import org.springframework.security.oauth2.core.oidc.user.OidcUser
+
+/**
+ * Stores nonces in memory
+ */
+class NonceUtil {
+  public static Set nonces = []
+
+  static String extractAndCheckNonce(OAuth2AuthenticationToken authentication){
+    OidcUser user = authentication.principal as OidcUser
+    String idToken = user.idToken.tokenValue
+    //extract token, parse, assert we issued it and remove it
+    nonces.remove((new JsonSlurper().parseText(new String(new Base64(true).decode(idToken.split("\\.")[1]))))?.nonce)
+  }
+
+  static String generateNonce(String sessionId){
+    String nonce = RandomStringUtils.random(32, sessionId.toCharArray())
+    nonces.add(nonce)
+    return nonce
+  }
+}

--- a/api-search/src/main/groovy/org/cedar/onestop/api/search/security/controller/LoginController.groovy
+++ b/api-search/src/main/groovy/org/cedar/onestop/api/search/security/controller/LoginController.groovy
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Controller
 import org.springframework.util.StringUtils
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.client.RestTemplate
 
@@ -40,10 +41,13 @@ class LoginController {
 
     @RequestMapping(value = SecurityConfig.LOGIN_PROFILE_ENDPOINT, method = [RequestMethod.GET, RequestMethod.OPTIONS])
     @ResponseBody
-    HashMap<String, Object> loginProfile(HttpServletRequest httpServletRequest, OAuth2AuthenticationToken authentication) {
+    HashMap<String, Object> loginProfile(HttpServletRequest httpServletRequest, OAuth2AuthenticationToken authentication, @RequestParam(value = "failure", required = false, defaultValue = "false") boolean failure) {
         if(authentication == null) {
             HashMap<String, Object> responseUnauthenticated = new HashMap<String, Object>()
             responseUnauthenticated.put("login", RequestUtil.getURL(httpServletRequest, DefaultLoginPageGeneratingFilter.DEFAULT_LOGIN_PAGE_URL))
+            if(failure) {
+                responseUnauthenticated.put("error", "Login was canceled or unsuccessful.")
+            }
             return responseUnauthenticated
         }
         else {

--- a/api-search/src/main/groovy/org/cedar/onestop/api/search/security/controller/LoginController.groovy
+++ b/api-search/src/main/groovy/org/cedar/onestop/api/search/security/controller/LoginController.groovy
@@ -75,16 +75,6 @@ class LoginController {
         }
     }
 
-    @RequestMapping(SecurityConfig.LOGIN_SUCCESS_ENDPOINT)
-    void loginSuccess(HttpServletResponse httpServletResponse) {
-        httpServletResponse.sendRedirect(loginGovConfiguration.loginSuccessRedirect)
-    }
-
-    @RequestMapping(SecurityConfig.LOGOUT_SUCCESS_ENDPOINT)
-    void logoutSuccess(HttpServletResponse httpServletResponse) {
-        httpServletResponse.sendRedirect(loginGovConfiguration.logoutSuccessRedirect)
-    }
-
     @RequestMapping(DefaultLoginPageGeneratingFilter.DEFAULT_LOGIN_PAGE_URL)
     String login() {
         // bypass the default Spring login page and go straight to login.gov authorization
@@ -92,4 +82,18 @@ class LoginController {
         return "redirect:" + authorizationRedirect
     }
 
+    @RequestMapping(SecurityConfig.LOGIN_SUCCESS_ENDPOINT)
+    void loginSuccess(HttpServletResponse httpServletResponse) {
+        httpServletResponse.sendRedirect(loginGovConfiguration.loginSuccessRedirect)
+    }
+
+    @RequestMapping(SecurityConfig.LOGIN_FAILURE_ENDPOINT)
+    void loginFailure(HttpServletResponse httpServletResponse) {
+        httpServletResponse.sendRedirect(loginGovConfiguration.loginFailureRedirect)
+    }
+
+    @RequestMapping(SecurityConfig.LOGOUT_SUCCESS_ENDPOINT)
+    void logoutSuccess(HttpServletResponse httpServletResponse) {
+        httpServletResponse.sendRedirect(loginGovConfiguration.logoutSuccessRedirect)
+    }
 }

--- a/api-search/src/main/resources/application.yml
+++ b/api-search/src/main/resources/application.yml
@@ -29,6 +29,7 @@ spring:
 logingov:
   allowed-origin: \${LOGIN_GOV_ALLOWED_ORIGIN}
   login-success-redirect: \${LOGIN_GOV_LOGIN_SUCCESS_REDIRECT}
+  login-failure-redirect: \${LOGIN_GOV_LOGIN_FAILURE_REDIRECT}
   logout-success-redirect: \${LOGIN_GOV_LOGOUT_SUCCESS_REDIRECT}
   keystore:
     alias: \${LOGIN_GOV_KEYSTORE_ALIAS}

--- a/kubernetes/deployments/onestop-api-search.yaml
+++ b/kubernetes/deployments/onestop-api-search.yaml
@@ -52,6 +52,8 @@ spec:
           value: "http://localhost:30000"
         - name: LOGIN_GOV_LOGIN_SUCCESS_REDIRECT
           value: "http://localhost:30000/onestop/"
+        - name: LOGIN_GOV_LOGIN_FAILURE_REDIRECT
+          value: "http://localhost:30000/onestop/"
         - name: LOGIN_GOV_LOGOUT_SUCCESS_REDIRECT
           value: "http://localhost:30000/onestop/"
         - name: LOGIN_GOV_KEYSTORE_FILE


### PR DESCRIPTION
Login.gov requires a nonce field to be generated for each session. 

This is a first pass on using the session id to generate a random 32 character string. We store this IN MEMORY until we get it back (which should be almost immediately) and then remove it. We met the basic requirements specified by login.gov but going forward we may consider using a hash instead of a random number generator. 

From login.gov docs- 
>nonce
A unique value at least 32 characters in length used to verify the integrity of the id_token and mitigate replay attacks. This value should include per-session state and be unguessable by attackers. This value will be present in the id_token of the token endpoint response, where clients will verify that the nonce claim value is equal to the value of the nonce parameter sent in the authentication request. Read more about nonce implementation in the spec.

From OpenId spec-
>15.5.2.  Nonce Implementation Notes
The nonce parameter value needs to include per-session state and be unguessable to attackers. One method to achieve this for Web Server Clients is to store a cryptographically random value as an HttpOnly session cookie and use a cryptographic hash of the value as the nonce parameter. In that case, the nonce in the returned ID Token is compared to the hash of the session cookie to detect ID Token replay by third parties. A related method applicable to JavaScript Clients is to store the cryptographically random value in HTML5 local storage and use a cryptographic hash of this value.

Also it looks like Spring Security 5 planned to support it but recently dropped it to the backlog
https://github.com/spring-projects/spring-security/issues/4442

Also an old spring library offers an in memory nonce service we could think about using. 
[InMemoryNonceServices](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/nonce/InMemoryNonceServices.html)
closes #769 