### PR TITLE
Remove version from artifact names.

### DIFF
--- a/api-metadata/build.gradle
+++ b/api-metadata/build.gradle
@@ -127,14 +127,15 @@ keystore {
 
 
 ext {
-  fatWarPath = file("${buildDir}/libs/${rootProject.name}-${project.name}-all-${project.version}.war")
+  fatWarPath = file("${buildDir}/libs/${rootProject.name}-${project.name}-all.war")
 }
 
 war {
   enabled = true
   // TODO disabled dynamic project-based name for #827, plan to re-enable in #828
   // baseName = "${rootProject.name}-${project.name}"
-  baseName = "onestop-metadata"
+  // baseName = "onestop-metadata"
+  archiveName = "onestop-metadata.${extension}"
   finalizedBy bootWar
 }
 

--- a/api-search/build.gradle
+++ b/api-search/build.gradle
@@ -138,7 +138,8 @@ war {
   enabled = true
   // TODO disabled dynamic project-based name for #827, plan to re-enable in #828
   // baseName = "${rootProject.name}-${project.name}"
-  baseName = "onestop-search"
+  // baseName = "onestop-search"
+  archiveName = "onestop-search.${extension}"
   finalizedBy bootWar
 }
 
@@ -193,7 +194,7 @@ task setupOpenapiGenPart1(type: Copy) {
   into "${buildDir}/tmp/schema"
 }
 
-// override the actual geometry so that the openApi is valid 
+// override the actual geometry so that the openApi is valid
 task setupOpenapiGenPart2(type: Copy) {
   dependsOn "setupOpenapiGenPart1"
   from "schema/components"

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -47,7 +47,7 @@ task tarResults(type: Tar) {
 
     from "${buildDir}/dist"
     baseName = 'onestop-client'
-    version = project.version
+    version = ''//project.version
     compression = 'gzip'
     extension = 'tar.gz'
     destinationDir = file("${buildDir}/libs")

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "onestop-client",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4996,7 +4996,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5017,12 +5018,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5037,17 +5040,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5164,7 +5170,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5176,6 +5183,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5190,6 +5198,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5197,12 +5206,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5221,6 +5232,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5301,7 +5313,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5313,6 +5326,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5398,7 +5412,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5434,6 +5449,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5453,6 +5469,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5496,12 +5513,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -9,7 +9,7 @@ build:
         DATE: now
         VCS_REF: local
         VERSION: 2.2.0
-        WAR_NAME: onestop-metadata-2.2.0.war
+        WAR_NAME: onestop-metadata.war
   - image: cedardevs/onestop-api-search
     context: ./api-search
     docker:
@@ -17,7 +17,7 @@ build:
         DATE: now
         VCS_REF: local
         VERSION: 2.2.0
-        WAR_NAME: onestop-search-2.2.0.war
+        WAR_NAME: onestop-search.war
   - image: cedardevs/onestop-client
     context: ./client
     docker:
@@ -25,7 +25,7 @@ build:
         DATE: now
         VCS_REF: local
         VERSION: 2.2.0
-        TAR_NAME: onestop-client-2.2.0.tar.gz
+        TAR_NAME: onestop-client.tar.gz
 
 deploy:
   helm:


### PR DESCRIPTION
Hotfix version of #886.

Created with `git format-patch -1` on 878-simplify-artifact-names-for-deployment branch.