### PR TITLE
increase headerlink hover color contrast

### DIFF
--- a/client/src/components/header/HeaderLink.jsx
+++ b/client/src/components/header/HeaderLink.jsx
@@ -14,7 +14,7 @@ const styleLink = {
 }
 
 const styleLinkHover = {
-  color: '#277cb2',
+  color: '#21ABE2',
 }
 
 const styleLinkFocusing = {


### PR DESCRIPTION
Used color from topic icons for a contrast ratio of 5.38:1 

Use https://webaim.org/resources/contrastchecker/ to check