### PR TITLE
800 search context order

### DIFF
--- a/client/src/actions/routing/CollectionSearchRouteActions.js
+++ b/client/src/actions/routing/CollectionSearchRouteActions.js
@@ -13,7 +13,6 @@ import {
   collectionNewSearchResultsReceived,
   collectionMoreResultsReceived,
   collectionSearchError,
-  collectionUpdateQueryText,
 } from './CollectionSearchStateActions'
 
 const getFilterFromState = state => {

--- a/client/src/actions/routing/CollectionSearchStateActions.js
+++ b/client/src/actions/routing/CollectionSearchStateActions.js
@@ -38,14 +38,6 @@ export const collectionSearchError = errors => ({
   errors,
 })
 
-export const COLLECTION_UPDATE_QUERY_TEXT = 'COLLECTION_UPDATE_QUERY_TEXT'
-export const collectionUpdateQueryText = queryText => {
-  return {
-    type: COLLECTION_UPDATE_QUERY_TEXT,
-    queryText: queryText,
-  }
-}
-
 export const COLLECTION_UPDATE_GEOMETRY = 'COLLECTION_UPDATE_GEOMETRY'
 export const collectionUpdateGeometry = geoJSON => {
   return {

--- a/client/src/components/cart/CartItem.jsx
+++ b/client/src/components/cart/CartItem.jsx
@@ -176,9 +176,9 @@ export default class CartItem extends React.Component {
     const {itemId, item, handleExpandableToggle} = this.props
 
     const title = (
-      <h2 key={'cartItemTitle'} style={styleTitle(this.state.expanded)}>
+      <h3 key={'cartItemTitle'} style={styleTitle(this.state.expanded)}>
         {item.title}
-      </h2>
+      </h3>
     )
 
     const summaryView = (

--- a/client/src/components/common/ui/ListView.jsx
+++ b/client/src/components/common/ui/ListView.jsx
@@ -24,13 +24,6 @@ const styleListInfo = {
   padding: 0,
 }
 
-const styleCountInfo = {
-  fontFamily: fontFamilySerif(),
-  fontSize: '1.0em',
-  justifyContent: 'flex-end',
-  padding: '0 1.618em 0 0',
-}
-
 const styleListControl = {
   display: 'flex',
   padding: '0.618em',
@@ -137,21 +130,15 @@ export default class ListView extends React.Component {
       customControl,
     } = this.props
     let message = `${resultsMessage ? resultsMessage : 'Results'}`
-    let countMessage = `Showing ${shown.toLocaleString()} of ${total.toLocaleString()}`
+    let countMessage = `Showing ${shown.toLocaleString()} of ${total.toLocaleString()} results for "${searchTerms}"`
     if (total === 0) {
       message = resultsMessageEmpty ? resultsMessageEmpty : 'No Results'
     }
 
     const listInfo = searchTerms ? (
       <h1 style={styleListInfo} key="list-view-info">
-        {'You searched for "' + searchTerms + '"'}
-      </h1>
-    ) : null
-
-    const countInfo = total !== 0 ? (
-      <h2 style={styleCountInfo} key="list-count-info">
         {countMessage}
-      </h2>
+      </h1>
     ) : message
 
     const toggleAvailable = ListItemComponent && GridItemComponent
@@ -233,7 +220,6 @@ export default class ListView extends React.Component {
     return (
       <div style={styleListView}>
         <FlexRow style={styleTopRow} items={[ listInfo, customControl ]} />
-        <FlexRow style={styleCountInfo} items={[ countInfo ]} />
         {controlElement}
         <div style={this.state.showAsGrid ? styleGrid : styleList}>
           {itemElements}

--- a/client/src/components/common/ui/ListView.jsx
+++ b/client/src/components/common/ui/ListView.jsx
@@ -139,7 +139,9 @@ export default class ListView extends React.Component {
       <h1 style={styleListInfo} key="list-view-info">
         {countMessage}
       </h1>
-    ) : message
+    ) : (
+      message
+    )
 
     const toggleAvailable = ListItemComponent && GridItemComponent
 

--- a/client/src/components/common/ui/ListView.jsx
+++ b/client/src/components/common/ui/ListView.jsx
@@ -130,7 +130,9 @@ export default class ListView extends React.Component {
       propsForItem,
       customControl,
     } = this.props
-    let countMessage = `Showing ${shown.toLocaleString()} of ${total.toLocaleString()} ${resultType ? resultType : 'results'} for "${searchTerms}"`
+    let countMessage = `Showing ${shown.toLocaleString()} of ${total.toLocaleString()} ${resultType
+      ? resultType
+      : 'results'} ${searchTerms ? 'for ' + searchTerms : ''}`
     let message = `${resultsMessage ? resultsMessage : countMessage}`
     if (total === 0) {
       message = resultsMessageEmpty ? resultsMessageEmpty : 'No Results'

--- a/client/src/components/common/ui/ListView.jsx
+++ b/client/src/components/common/ui/ListView.jsx
@@ -142,9 +142,9 @@ export default class ListView extends React.Component {
     }
 
     const listInfo = (
-      <h1 style={styleListInfo} key="list-view-info">
+      <h2 style={styleListInfo} key="list-view-info">
         {message}
-      </h1>
+      </h2>
     )
 
     const toggleAvailable = ListItemComponent && GridItemComponent

--- a/client/src/components/common/ui/ListView.jsx
+++ b/client/src/components/common/ui/ListView.jsx
@@ -118,6 +118,7 @@ export default class ListView extends React.Component {
   render() {
     const {
       items,
+      resultType,
       resultsMessage,
       resultsMessageEmpty,
       searchTerms,
@@ -129,18 +130,16 @@ export default class ListView extends React.Component {
       propsForItem,
       customControl,
     } = this.props
-    let message = `${resultsMessage ? resultsMessage : 'Results'}`
-    let countMessage = `Showing ${shown.toLocaleString()} of ${total.toLocaleString()} results for "${searchTerms}"`
+    let countMessage = `Showing ${shown.toLocaleString()} of ${total.toLocaleString()} ${resultType ? resultType : 'results'} for "${searchTerms}"`
+    let message = `${resultsMessage ? resultsMessage : countMessage}`
     if (total === 0) {
       message = resultsMessageEmpty ? resultsMessageEmpty : 'No Results'
     }
 
-    const listInfo = searchTerms ? (
+    const listInfo = (
       <h1 style={styleListInfo} key="list-view-info">
-        {countMessage}
+        {message}
       </h1>
-    ) : (
-      message
     )
 
     const toggleAvailable = ListItemComponent && GridItemComponent

--- a/client/src/components/common/ui/ListView.jsx
+++ b/client/src/components/common/ui/ListView.jsx
@@ -132,7 +132,7 @@ export default class ListView extends React.Component {
     } = this.props
     let countMessage = `Showing ${shown.toLocaleString()} of ${total.toLocaleString()} ${resultType
       ? resultType
-      : 'results'} ${searchTerms ? 'for ' + searchTerms : ''}`
+      : 'results'} ${searchTerms ? 'for "' + searchTerms + '"' : ''}`
     let message = `${resultsMessage ? resultsMessage : countMessage}`
     if (total === 0) {
       message = resultsMessageEmpty ? resultsMessageEmpty : 'No Results'

--- a/client/src/components/common/ui/ListView.jsx
+++ b/client/src/components/common/ui/ListView.jsx
@@ -130,10 +130,13 @@ export default class ListView extends React.Component {
       propsForItem,
       customControl,
     } = this.props
+
     let countMessage = `Showing ${shown.toLocaleString()} of ${total.toLocaleString()} ${resultType
       ? resultType
       : 'results'} ${searchTerms ? 'for "' + searchTerms + '"' : ''}`
+
     let message = `${resultsMessage ? resultsMessage : countMessage}`
+
     if (total === 0) {
       message = resultsMessageEmpty ? resultsMessageEmpty : 'No Results'
     }

--- a/client/src/components/common/ui/ListView.jsx
+++ b/client/src/components/common/ui/ListView.jsx
@@ -15,7 +15,7 @@ const styleListView = {
 const styleTopRow = {
   justifyContent: 'space-between',
   alignItems: 'center',
-  margin: '0 1.618em 0.618em 0',
+  margin: '0 1.618em 0 0',
 }
 
 const styleListInfo = {
@@ -27,12 +27,8 @@ const styleListInfo = {
 const styleCountInfo = {
   fontFamily: fontFamilySerif(),
   fontSize: '1.0em',
-}
-
-const styleSearchInfo = {
-  fontFamily: fontFamilySerif(),
-  fontSize: '1.0em',
-  padding: 0,
+  justifyContent: 'flex-end',
+  padding: '0 1.618em 0 0',
 }
 
 const styleListControl = {
@@ -140,30 +136,23 @@ export default class ListView extends React.Component {
       propsForItem,
       customControl,
     } = this.props
-
     let message = `${resultsMessage ? resultsMessage : 'Results'}`
-    let countMessage = `Showing ${shown} of ${total}`
+    let countMessage = `Showing ${shown.toLocaleString()} of ${total.toLocaleString()}`
     if (total === 0) {
       message = resultsMessageEmpty ? resultsMessageEmpty : 'No Results'
     }
 
-    const listInfo = (
+    const listInfo = searchTerms ? (
       <h1 style={styleListInfo} key="list-view-info">
-        {message}
+        {'You searched for "' + searchTerms + '"'}
       </h1>
-    )
+    ) : null
 
-    const countInfo = (
+    const countInfo = total !== 0 ? (
       <h2 style={styleCountInfo} key="list-count-info">
         {countMessage}
       </h2>
-    )
-
-    const searchTermsMessage = searchTerms ? (
-      <h3 style={styleSearchInfo} key="search-info">
-        {'You searched for "' + searchTerms + '"'}
-      </h3>
-    ) : null
+    ) : message
 
     const toggleAvailable = ListItemComponent && GridItemComponent
 
@@ -243,11 +232,8 @@ export default class ListView extends React.Component {
 
     return (
       <div style={styleListView}>
-        <FlexRow
-          style={styleTopRow}
-          items={[ listInfo, countInfo, customControl ]}
-        />
-        {searchTermsMessage}
+        <FlexRow style={styleTopRow} items={[ listInfo, customControl ]} />
+        <FlexRow style={styleCountInfo} items={[ countInfo ]} />
         {controlElement}
         <div style={this.state.showAsGrid ? styleGrid : styleList}>
           {itemElements}

--- a/client/src/components/common/ui/ListView.jsx
+++ b/client/src/components/common/ui/ListView.jsx
@@ -24,6 +24,17 @@ const styleListInfo = {
   padding: 0,
 }
 
+const styleCountInfo = {
+  fontFamily: fontFamilySerif(),
+  fontSize: '1.0em',
+}
+
+const styleSearchInfo = {
+  fontFamily: fontFamilySerif(),
+  fontSize: '1.0em',
+  padding: 0,
+}
+
 const styleListControl = {
   display: 'flex',
   padding: '0.618em',
@@ -120,6 +131,7 @@ export default class ListView extends React.Component {
       items,
       resultsMessage,
       resultsMessageEmpty,
+      searchTerms,
       shown,
       total,
       onItemSelect,
@@ -136,15 +148,22 @@ export default class ListView extends React.Component {
     }
 
     const listInfo = (
-      <h2 style={styleListInfo} key="list-view-info">
+      <h1 style={styleListInfo} key="list-view-info">
         {message}
+      </h1>
+    )
+
+    const countInfo = (
+      <h2 style={styleCountInfo} key="list-count-info">
+        {countMessage}
       </h2>
     )
-    const countInfo = (
-      <h3 style={styleListInfo} key="list-view-info">
-        {countMessage}
+
+    const searchTermsMessage = searchTerms ? (
+      <h3 style={styleSearchInfo} key="search-info">
+        {'You searched for "' + searchTerms + '"'}
       </h3>
-    )
+    ) : null
 
     const toggleAvailable = ListItemComponent && GridItemComponent
 
@@ -228,6 +247,7 @@ export default class ListView extends React.Component {
           style={styleTopRow}
           items={[ listInfo, countInfo, customControl ]}
         />
+        {searchTermsMessage}
         {controlElement}
         <div style={this.state.showAsGrid ? styleGrid : styleList}>
           {itemElements}

--- a/client/src/components/common/ui/ListView.jsx
+++ b/client/src/components/common/ui/ListView.jsx
@@ -129,18 +129,21 @@ export default class ListView extends React.Component {
       customControl,
     } = this.props
 
-    let message = `${resultsMessage
-      ? resultsMessage
-      : 'Results'} (showing ${shown} of ${total})`
-
+    let message = `${resultsMessage ? resultsMessage : 'Results'}`
+    let countMessage = `Showing ${shown} of ${total}`
     if (total === 0) {
       message = resultsMessageEmpty ? resultsMessageEmpty : 'No Results'
     }
 
     const listInfo = (
-      <h1 style={styleListInfo} key="list-view-info">
+      <h2 style={styleListInfo} key="list-view-info">
         {message}
-      </h1>
+      </h2>
+    )
+    const countInfo = (
+      <h3 style={styleListInfo} key="list-view-info">
+        {countMessage}
+      </h3>
     )
 
     const toggleAvailable = ListItemComponent && GridItemComponent
@@ -221,7 +224,10 @@ export default class ListView extends React.Component {
 
     return (
       <div style={styleListView}>
-        <FlexRow style={styleTopRow} items={[ listInfo, customControl ]} />
+        <FlexRow
+          style={styleTopRow}
+          items={[ listInfo, countInfo, customControl ]}
+        />
         {controlElement}
         <div style={this.state.showAsGrid ? styleGrid : styleList}>
           {itemElements}

--- a/client/src/components/filters/FilterHeading.jsx
+++ b/client/src/components/filters/FilterHeading.jsx
@@ -40,7 +40,7 @@ export default class FilterHeading extends React.Component {
             alt={`${this.props.text} Icon`}
           />
         </div>
-        <h2 style={styleText}>{this.props.text}</h2>
+        <h3 style={styleText}>{this.props.text}</h3>
       </div>
     )
   }

--- a/client/src/components/filters/collections/CollectionFilters.jsx
+++ b/client/src/components/filters/collections/CollectionFilters.jsx
@@ -130,7 +130,7 @@ class CollectionFilters extends React.Component {
     }
 
     const heading = (
-      <h1
+      <h2
         key="filtersH1"
         tabIndex={-1}
         ref={header => (this.headerRef = header)}
@@ -139,7 +139,7 @@ class CollectionFilters extends React.Component {
         style={styleOverallHeadingApplied}
       >
         Filters
-      </h1>
+      </h2>
     )
 
     const buttonHide = (

--- a/client/src/components/filters/collections/CollectionSearch.jsx
+++ b/client/src/components/filters/collections/CollectionSearch.jsx
@@ -80,7 +80,9 @@ const styleSearchButton = {fontSize: '1em', display: 'inline'}
 class CollectionSearch extends React.Component {
   constructor(props) {
     super(props)
+    const {queryString} = this.props
     this.state = {
+      queryString: queryString,
       warning: '',
       hoveringWarningClose: false,
       focusingWarningClose: false,
@@ -90,6 +92,12 @@ class CollectionSearch extends React.Component {
   handleMouseOverWarningClose = event => {
     this.setState({
       hoveringWarningClose: true,
+    })
+  }
+
+  handleInputChange = value => {
+    this.setState({
+      queryString: value,
     })
   }
 
@@ -112,12 +120,11 @@ class CollectionSearch extends React.Component {
   }
 
   clearQueryString = () => {
-    this.setState({warning: ''})
-    this.props.collectionUpdateQueryText('')
+    this.setState({warning: '', queryString: ''})
   }
 
   validateAndSubmit = () => {
-    let trimmedQuery = _.trim(this.props.queryString)
+    let trimmedQuery = _.trim(this.state.queryString)
     if (!trimmedQuery) {
       this.setState({warning: 'You must enter a search term.'})
     }
@@ -136,8 +143,8 @@ class CollectionSearch extends React.Component {
   }
 
   render() {
-    const {home, collectionUpdateQueryText, queryString} = this.props
-    const {warning, focusingWarningClose} = this.state
+    const {home} = this.props
+    const {warning, focusingWarningClose, queryString} = this.state
 
     const instructionalCopy = home ? 'Search NOAA Data' : 'New NOAA Data Search'
 
@@ -187,7 +194,7 @@ class CollectionSearch extends React.Component {
         <div role="search" style={styleSearchWrapper}>
           <TextSearchField
             onEnterKeyDown={this.validateAndSubmit}
-            onChange={collectionUpdateQueryText}
+            onChange={this.handleInputChange}
             onClear={this.clearQueryString}
             value={queryString}
             warningPopup={warningPopup}

--- a/client/src/components/filters/collections/CollectionSearchContainer.js
+++ b/client/src/components/filters/collections/CollectionSearchContainer.js
@@ -1,7 +1,6 @@
 import {connect} from 'react-redux'
 import {withRouter} from 'react-router'
 import CollectionSearch from './CollectionSearch'
-import {collectionUpdateQueryText} from '../../../actions/routing/CollectionSearchStateActions'
 import {submitCollectionSearchWithQueryText} from '../../../actions/routing/CollectionSearchRouteActions'
 
 const mapStateToProps = state => {
@@ -15,8 +14,6 @@ const mapDispatchToProps = (dispatch, ownProps) => {
     submit: text => {
       dispatch(submitCollectionSearchWithQueryText(ownProps.history, text))
     },
-    collectionUpdateQueryText: text =>
-      dispatch(collectionUpdateQueryText(text)), // TODO is this prop function really needed... sorta maybe?
   }
 }
 

--- a/client/src/components/filters/facet/FacetFilter.jsx
+++ b/client/src/components/filters/facet/FacetFilter.jsx
@@ -67,13 +67,13 @@ export default class FacetFilter extends React.Component {
       const expandableKey = category
 
       const highLevelHeading = (
-        <h3
+        <h4
           id={facetCategory.id}
           style={{fontSize: '1em', fontWeight: 'normal', display: 'inline'}}
         >
           <span aria-hidden="true">&#9776;&nbsp;</span>
           {category}
-        </h3>
+        </h4>
       )
 
       const expandableFacets = (

--- a/client/src/components/filters/granules/GranuleFilters.jsx
+++ b/client/src/components/filters/granules/GranuleFilters.jsx
@@ -131,7 +131,7 @@ class GranuleFilters extends React.Component {
     }
 
     const heading = (
-      <h1
+      <h2
         key="filtersH1"
         tabIndex={-1}
         ref={header => (this.headerRef = header)}
@@ -140,7 +140,7 @@ class GranuleFilters extends React.Component {
         style={styleOverallHeadingApplied}
       >
         Filters
-      </h1>
+      </h2>
     )
 
     const buttonHide = (

--- a/client/src/components/filters/spatial/MapFilter.jsx
+++ b/client/src/components/filters/spatial/MapFilter.jsx
@@ -339,7 +339,7 @@ export default class MapFilter extends React.Component {
         </label>
         {inputColumn}
         <div style={styleSeparator} />
-        <h3 style={{paddingLeft: '0.308em'}}>Additional Filtering Options:</h3>
+        <h4 style={{paddingLeft: '0.308em'}}>Additional Filtering Options:</h4>
         {excludeGlobalCheckbox}
       </div>
     )

--- a/client/src/components/header/Header.jsx
+++ b/client/src/components/header/Header.jsx
@@ -161,9 +161,15 @@ class Header extends React.Component {
     ) : null
 
     const welcomeUser = userEmail ? (
-      <div style={styleUserWelcome} key="emailDisplay">
-        Logged in as {userEmail}
-      </div>
+      <FlexRow
+        style={styleUserWelcome}
+        key="welcomeUser"
+        items={[
+          <div style={styleUserWelcome} key="emailDisplay">
+            Logged in as {userEmail}
+          </div>,
+        ]}
+      />
     ) : null
 
     const menuContent = (
@@ -227,11 +233,7 @@ class Header extends React.Component {
       <Route path="/">
         <div style={styleWrapper}>
           <div style={styleHeader}>
-            <FlexRow
-              style={styleUserWelcome}
-              key="welcomeUser"
-              items={[ welcomeUser ]}
-            />
+            {welcomeUser}
             <FlexRow
               style={styleHeaderFlexRow}
               items={[

--- a/client/src/components/layout/Layout.jsx
+++ b/client/src/components/layout/Layout.jsx
@@ -55,10 +55,7 @@ export default class Layout extends React.Component {
               visible={bannerVisible}
               key={'banner'}
             />,
-            <Content
-              middle={title}
-              key={'title'}
-            />,
+            <Content middle={title} key={'title'} />,
             <Content
               left={left}
               leftWidth={leftWidth}

--- a/client/src/components/layout/Layout.jsx
+++ b/client/src/components/layout/Layout.jsx
@@ -7,8 +7,6 @@ import Banner from './Banner'
 import Content from './Content'
 import Footer from './Footer'
 import Disclaimer from './Disclaimer'
-import FlexRow from '../common/ui/FlexRow'
-import {fontFamilySerif} from '../../utils/styleUtils'
 
 const defaultPadding = '1em'
 
@@ -18,24 +16,9 @@ const styleContainer = {
   overflow: 'hidden',
 }
 
-const styleTitleRow = {
-  justifyContent: 'flex-start',
-  padding: '0.618em 0 0.618em 0',
-  margin: 0,
-  backgroundColor: '#222C37',
-  fontFamily: fontFamilySerif(),
-}
-
-const styleTitle = {
-  fontSize: '1.2em',
-  padding: '0 0 0 18em',
-  margin: 0,
-}
-
 export default class Layout extends React.Component {
   render() {
     const {
-      location,
       style,
       disclaimer,
       header,
@@ -43,6 +26,7 @@ export default class Layout extends React.Component {
       bannerHeight,
       bannerArcHeight,
       bannerVisible,
+      title,
       left,
       leftWidth,
       leftOpen,
@@ -58,21 +42,6 @@ export default class Layout extends React.Component {
 
     const styles = Object.assign({}, styleContainer, style)
 
-    const searchResultPageTitle =
-      location.pathname && location.pathname.includes('collections')
-        ? 'Collection search results'
-        : location.pathname && location.pathname.includes('granules')
-          ? 'Granule search results'
-          : null
-
-    const titleRow = searchResultPageTitle ? (
-        <FlexColumn items={[ <FlexRow
-            style={styleTitleRow}
-            key='result-page-title'
-            items={[ <h1 key='result-title-row' style={styleTitle}>{searchResultPageTitle}</h1> ]}
-        /> ]} />
-    ) : null
-
     return (
       <Background>
         <FlexColumn
@@ -86,7 +55,10 @@ export default class Layout extends React.Component {
               visible={bannerVisible}
               key={'banner'}
             />,
-            <FlexColumn key={'title'} items={[ titleRow ]} />,
+            <Content
+              middle={title}
+              key={'title'}
+            />,
             <Content
               left={left}
               leftWidth={leftWidth}
@@ -100,11 +72,6 @@ export default class Layout extends React.Component {
               rightVisible={rightVisible}
               padding={defaultPadding}
               key={'content'}
-              style={{
-                position: 'relative',
-                zIndex: 1,
-                margin: '-1.618em 0 0 0',
-              }}
             />,
             <Footer content={footer} padding={defaultPadding} key={'footer'} />,
           ]}

--- a/client/src/components/layout/Layout.jsx
+++ b/client/src/components/layout/Layout.jsx
@@ -7,6 +7,8 @@ import Banner from './Banner'
 import Content from './Content'
 import Footer from './Footer'
 import Disclaimer from './Disclaimer'
+import FlexRow from '../common/ui/FlexRow'
+import {fontFamilySerif} from '../../utils/styleUtils'
 
 const defaultPadding = '1em'
 
@@ -16,9 +18,24 @@ const styleContainer = {
   overflow: 'hidden',
 }
 
+const styleTitleRow = {
+  justifyContent: 'flex-start',
+  padding: '0.618em 0 0.618em 0',
+  margin: 0,
+  backgroundColor: '#222C37',
+  fontFamily: fontFamilySerif(),
+}
+
+const styleTitle = {
+  fontSize: '1.2em',
+  padding: '0 0 0 18em',
+  margin: 0,
+}
+
 export default class Layout extends React.Component {
   render() {
     const {
+      location,
       style,
       disclaimer,
       header,
@@ -41,6 +58,21 @@ export default class Layout extends React.Component {
 
     const styles = Object.assign({}, styleContainer, style)
 
+    const searchResultPageTitle =
+      location.pathname && location.pathname.includes('collections')
+        ? 'Collection search results'
+        : location.pathname && location.pathname.includes('granules')
+          ? 'Granule search results'
+          : null
+
+    const titleRow = searchResultPageTitle ? (
+        <FlexColumn items={[ <FlexRow
+            style={styleTitleRow}
+            key='result-page-title'
+            items={[ <h1 key='result-title-row' style={styleTitle}>{searchResultPageTitle}</h1> ]}
+        /> ]} />
+    ) : null
+
     return (
       <Background>
         <FlexColumn
@@ -54,6 +86,7 @@ export default class Layout extends React.Component {
               visible={bannerVisible}
               key={'banner'}
             />,
+            <FlexColumn key={'title'} items={[ titleRow ]} />,
             <Content
               left={left}
               leftWidth={leftWidth}
@@ -67,6 +100,11 @@ export default class Layout extends React.Component {
               rightVisible={rightVisible}
               padding={defaultPadding}
               key={'content'}
+              style={{
+                position: 'relative',
+                zIndex: 1,
+                margin: '-1.618em 0 0 0',
+              }}
             />,
             <Footer content={footer} padding={defaultPadding} key={'footer'} />,
           ]}

--- a/client/src/components/results/collections/CollectionCard.jsx
+++ b/client/src/components/results/collections/CollectionCard.jsx
@@ -247,7 +247,7 @@ export default class CollectionCard extends React.Component {
           >
             {this.renderThumbnailMap()}
             <div style={styleArchMerged}>
-              <h2 style={styleTitle}>{title}</h2>
+              <h3 style={styleTitle}>{title}</h3>
             </div>
           </button>
         </div>

--- a/client/src/components/results/collections/Collections.jsx
+++ b/client/src/components/results/collections/Collections.jsx
@@ -46,9 +46,8 @@ export default class Collections extends React.Component {
         />
         <ListView
           items={results}
-          resultsMessage={
-            'Collections matching search term "' + queryText + '"'
-          }
+          resultsMessage={'Collection search results'}
+          searchTerms={queryText}
           shown={returnedHits}
           total={totalHits}
           onItemSelect={this.itemSelect}

--- a/client/src/components/results/collections/Collections.jsx
+++ b/client/src/components/results/collections/Collections.jsx
@@ -25,6 +25,7 @@ export default class Collections extends React.Component {
 
   render() {
     const {results, returnedHits, totalHits, fetchMoreResults} = this.props
+    const queryText = this.props.collectionDetailFilter.queryText
 
     const showMoreButton =
       returnedHits < totalHits ? (
@@ -39,13 +40,13 @@ export default class Collections extends React.Component {
     return (
       <div style={styleCollections}>
         <Meta
-          title="Collection Search Results"
+          title={'Collection Search Results for ' + queryText}
           formatTitle={true}
           robots="noindex"
         />
         <ListView
           items={results}
-          resultsMessage={'Search Results'}
+          resultsMessage={'Collections matching search term \"' + queryText + '\"'}
           shown={returnedHits}
           total={totalHits}
           onItemSelect={this.itemSelect}

--- a/client/src/components/results/collections/Collections.jsx
+++ b/client/src/components/results/collections/Collections.jsx
@@ -46,6 +46,7 @@ export default class Collections extends React.Component {
         />
         <ListView
           items={results}
+          resultType="collections"
           resultsMessage={'Collection search results'}
           searchTerms={queryText}
           shown={returnedHits}

--- a/client/src/components/results/collections/Collections.jsx
+++ b/client/src/components/results/collections/Collections.jsx
@@ -46,7 +46,9 @@ export default class Collections extends React.Component {
         />
         <ListView
           items={results}
-          resultsMessage={'Collections matching search term \"' + queryText + '\"'}
+          resultsMessage={
+            'Collections matching search term "' + queryText + '"'
+          }
           shown={returnedHits}
           total={totalHits}
           onItemSelect={this.itemSelect}

--- a/client/src/components/results/collections/Collections.jsx
+++ b/client/src/components/results/collections/Collections.jsx
@@ -47,7 +47,6 @@ export default class Collections extends React.Component {
         <ListView
           items={results}
           resultType="collections"
-          resultsMessage={'Collection search results'}
           searchTerms={queryText}
           shown={returnedHits}
           total={totalHits}

--- a/client/src/components/results/granules/GranuleList.jsx
+++ b/client/src/components/results/granules/GranuleList.jsx
@@ -110,6 +110,7 @@ export default class GranuleList extends React.Component {
           <GranuleListLegend usedProtocols={usedProtocols} />
           <ListView
             items={results}
+            resultType="collection files"
             resultsMessage={'Collection Files'}
             shown={returnedHits}
             total={totalHits}

--- a/client/src/components/results/granules/GranuleList.jsx
+++ b/client/src/components/results/granules/GranuleList.jsx
@@ -111,7 +111,6 @@ export default class GranuleList extends React.Component {
           <ListView
             items={results}
             resultType="collection files"
-            resultsMessage={'Collection Files'}
             shown={returnedHits}
             total={totalHits}
             onItemSelect={selectCollection}

--- a/client/src/components/results/granules/GranuleListLegend.jsx
+++ b/client/src/components/results/granules/GranuleListLegend.jsx
@@ -61,9 +61,9 @@ export default class GranuleListLegend extends React.Component {
 
     return (
       <div style={styleLegend}>
-        <h1 style={styleHeading} aria-label="Access Protocols Legend">
+        <h2 style={styleHeading} aria-label="Access Protocols Legend">
           Access Protocols:
-        </h1>
+        </h2>
         <ul style={styleLegendList}>{legendItems}</ul>
       </div>
     )

--- a/client/src/components/results/granules/GranuleListResult.jsx
+++ b/client/src/components/results/granules/GranuleListResult.jsx
@@ -150,11 +150,11 @@ class ListResult extends React.Component {
   ) {
     return (
       <div key={'ListResult::timeAndSpace'}>
-        <h3 style={styleSectionHeader}>Time Period:</h3>
+        <h4 style={styleSectionHeader}>Time Period:</h4>
         <div style={styleSectionContent}>
           {util.buildTimePeriodString(beginDate, beginYear, endDate, endYear)}
         </div>
-        <h3 style={styleSectionHeader}>Bounding Coordinates:</h3>
+        <h4 style={styleSectionHeader}>Bounding Coordinates:</h4>
         <div style={styleSectionContent}>
           {util.buildCoordinatesString(spatialBounding)}
         </div>
@@ -251,7 +251,7 @@ class ListResult extends React.Component {
 
     return (
       <div key={'ListResult::accessLinks'}>
-        <h3 style={styleSectionHeader}>Data Access Links:</h3>
+        <h4 style={styleSectionHeader}>Data Access Links:</h4>
         <ul style={util.styleProtocolList}>{badgesElement}</ul>
       </div>
     )
@@ -317,7 +317,7 @@ class ListResult extends React.Component {
     }
 
     const title = (
-      <h2
+      <h3
         id={`ListResult::title::${itemId}`}
         key={`ListResult::title::${itemId}`}
         tabIndex={-1}
@@ -329,7 +329,7 @@ class ListResult extends React.Component {
         style={styleOverallHeadingApplied}
       >
         {item.title}
-      </h2>
+      </h3>
     )
 
     const granuleDownloadable = granuleDownloadableLinks([ item ]).length > 0

--- a/client/src/components/root/Root.jsx
+++ b/client/src/components/root/Root.jsx
@@ -96,14 +96,10 @@ export default class Root extends React.Component {
       <div style={styleHiddenTitleRow}>
         <Switch>
           <Route path={ROUTE.collections.path} exact>
-            <h1 key="collection-result-title">
-              Collection search results
-            </h1>
+            <h1 key="collection-result-title">Collection search results</h1>
           </Route>
           <Route path={ROUTE.granules.path}>
-            <h1 key="granule-result-title">
-              Granule search results
-            </h1>
+            <h1 key="granule-result-title">Granule search results</h1>
           </Route>
         </Switch>
       </div>

--- a/client/src/components/root/Root.jsx
+++ b/client/src/components/root/Root.jsx
@@ -45,6 +45,16 @@ const styleBrowserWarningParagraph = {
   textAlign: 'center',
 }
 
+//web aim suggested styling for hidden content
+const styleHiddenTitleRow = {
+  position: 'absolute',
+  left: '-10000px',
+  top: 'auto',
+  width: '1px',
+  height: '1px',
+  overflow: 'hidden',
+}
+
 // component
 export default class Root extends React.Component {
   constructor(props) {
@@ -81,6 +91,23 @@ export default class Root extends React.Component {
     const bannerVisible = isHome(location.pathname)
     const leftVisible = isSearch(location.pathname)
     const rightVisible = false
+
+    const titleRow = (
+      <div style={styleHiddenTitleRow}>
+        <Switch>
+          <Route path={ROUTE.collections.path} exact>
+            <h1 key="collection-result-title">
+              Collection search results
+            </h1>
+          </Route>
+          <Route path={ROUTE.granules.path}>
+            <h1 key="granule-result-title">
+              Granule search results
+            </h1>
+          </Route>
+        </Switch>
+      </div>
+    )
 
     const middle = (
       <div style={{width: '100%'}}>
@@ -151,6 +178,7 @@ export default class Root extends React.Component {
           bannerHeight={'30em'}
           bannerArcHeight={'15em'}
           bannerVisible={bannerVisible}
+          title={titleRow}
           /* - Left - */
           left={leftOpen ? <FiltersContainer /> : <FiltersHiddenContainer />}
           leftWidth={leftOpen ? '20em' : '2em'}

--- a/client/src/components/root/Root.jsx
+++ b/client/src/components/root/Root.jsx
@@ -141,6 +141,7 @@ export default class Root extends React.Component {
     else {
       return (
         <Layout
+          location={location}
           /* - Disclaimer - */
           disclaimer={<DisclaimerContainer />}
           /* - Header - */

--- a/client/src/reducers/search/collectionFilter.js
+++ b/client/src/reducers/search/collectionFilter.js
@@ -1,6 +1,5 @@
 import Immutable from 'seamless-immutable'
 import {
-  COLLECTION_UPDATE_QUERY_TEXT,
   COLLECTION_UPDATE_GEOMETRY,
   COLLECTION_REMOVE_GEOMETRY,
   COLLECTION_UPDATE_DATE_RANGE,
@@ -26,9 +25,6 @@ export const initialState = Immutable({
 
 export const collectionFilter = (state = initialState, action) => {
   switch (action.type) {
-    case COLLECTION_UPDATE_QUERY_TEXT:
-      return Immutable.set(state, 'queryText', action.queryText)
-
     case COLLECTION_UPDATE_GEOMETRY:
       return Immutable.set(state, 'geoJSON', action.geoJSON)
 

--- a/client/test/reducers/search/collectionFilter.test.js
+++ b/client/test/reducers/search/collectionFilter.test.js
@@ -4,7 +4,6 @@ import {
   initialState,
 } from '../../../src/reducers/search/collectionFilter'
 import {
-  collectionUpdateQueryText,
   collectionUpdateDateRange,
   collectionRemoveDateRange,
   collectionUpdateGeometry,
@@ -279,20 +278,6 @@ describe('The collection filter reducer', function(){
       },
     }
     const paramActionTestCases = [
-      {
-        name: 'sets query text',
-        initialState: initialState,
-        function: collectionUpdateQueryText,
-        params: [ 'foobar' ],
-        expectedChanges: {queryText: 'foobar'},
-      },
-      {
-        name: 'resets query text',
-        initialState: nonInitialState,
-        function: collectionUpdateQueryText,
-        params: [ 'foobar' ],
-        expectedChanges: {queryText: 'foobar'},
-      },
       {
         name: 'sets start date',
         initialState: initialState,


### PR DESCRIPTION
Resolves #800 
Functionally, this is ready for review. 
Summary of changes-
- hidden h1 on result pages
- header structure level on all list result views (collections, granules, cart). 
- text box has local state for input, queryText only set after submit
- commas in the search result header (e.g. showing 1,000 of 10,000) 

There is an action, [`collectionUpdateQueryText()`](https://github.com/cedardevs/onestop/blob/aac6abc9b656c156949e35e4b786bfd4a6311c3d/client/src/actions/routing/CollectionSearchStateActions.js), that is no longer needed by the code, but is [used in a test as a setup step](https://github.com/cedardevs/onestop/blob/aac6abc9b656c156949e35e4b786bfd4a6311c3d/client/test/actions/routing/CollectionSearchRouteActions.test.js#L66). We also need to remove [these tests for it](https://github.com/cedardevs/onestop/blob/aac6abc9b656c156949e35e4b786bfd4a6311c3d/client/test/reducers/search/collectionFilter.test.js#L285), but they were easily removed without incident unlike the aforementioned one. 