### PR TITLE
resolve jackson dependency CVE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,8 +51,8 @@ subprojects {
       resolutionStrategy.eachDependency { DependencyResolveDetails details ->
         if (details.requested.group == 'com.fasterxml.jackson.core' && details.requested.name == 'jackson-databind') {
           if (details.requested.version.startsWith('2.9') && details.requested.version <= '2.9.9') {
-            details.useVersion '2.9.9'
-            details.because 'fixes vulnerability in 2.9.x before 2.9.9'
+            details.useVersion '2.9.9.1'
+            details.because 'fixes vulnerability in 2.9.9 and before'
           }
         }
         if (details.requested.group == 'org.bouncycastle' && details.requested.name == 'bcprov-jdk15on') {


### PR DESCRIPTION
This resolves one of the vulnerabilities, but there are still two from kafka but semere is working on upgrading those. 