### PR TITLE
fix for zero coordinates bug

### DIFF
--- a/client/src/utils/geoUtils.js
+++ b/client/src/utils/geoUtils.js
@@ -78,7 +78,7 @@ export const convertBboxToGeoJson = (west, south, east, north) => {
   const n = textToNumber(north)
 
   // Invalid coordinates checks
-  if (!w || !s || !e || !n) {
+  if (!w && w !== 0 || !s && s !== 0 || !e && e !== 0 || !n && n !== 0 ) {
     return null
   }
 


### PR DESCRIPTION
It was what we assumed- a check for null was wrongly assuming 0 was unwanted. 