### PR TITLE
only request granule count if filters are applied

### DIFF
--- a/client/src/actions/routing/CollectionDetailRouteActions.js
+++ b/client/src/actions/routing/CollectionDetailRouteActions.js
@@ -70,8 +70,15 @@ export const submitCollectionDetail = (history, id, filterState) => {
     }
     // send notifications that request has begun, updating filter state if needed
     dispatch(collectionDetailRequested(id, filterState))
-    dispatch(granuleMatchingCountRequested())
     const updatedFilterState = getFilterFromState(getState())
+    if (
+      updatedFilterState.geoJSON ||
+      updatedFilterState.endDateTime ||
+      _.size(updatedFilterState.selectedFacets) >= 1 ||
+      updatedFilterState.startDateTime
+    ) {
+      dispatch(granuleMatchingCountRequested())
+    }
     // update URL if needed (required to display loading indicator on the correct page)
     navigateToDetailUrl(history, updatedFilterState)
     // start async request

--- a/client/test/actions/routing/CollectionDetailRouteActions.test.js
+++ b/client/test/actions/routing/CollectionDetailRouteActions.test.js
@@ -127,7 +127,12 @@ describe('collection detail action', function(){
           } = store.getState().search
 
           expect(collectionDetailRequest.inFlight).toBeTruthy()
-          expect(collectionDetailRequest.backgroundInFlight).toBeTruthy()
+          // backgroundInFlight state is determined by GRANULE_MATCHING_COUNT_REQUESTED action
+          // which now only applies intelligently (if there are filters applied)
+          // if no filters are applied, the granule count request is unnecessary
+          // In other words: if this test were to simulate applied filters, this would be truthy,
+          // but for now it's falsy!
+          expect(collectionDetailRequest.backgroundInFlight).toBeFalsy()
           expect(collectionDetailRequest.requestedID).toEqual('uuid-ABC')
           expect(collectionDetailFilter.selectedCollectionIds).toEqual([
             'uuid-ABC',


### PR DESCRIPTION
This change conditionally fetches granule count based on filters existing or not. 

However, when I comment out 'dispatch(granuleMatchingCountRequested())` completely, I cant really tell a difference. The granule count seems accurate either way.