### PR TITLE
969 analytics fix

### DIFF
--- a/client/src/components/analytics/GoogleAnalytics.jsx
+++ b/client/src/components/analytics/GoogleAnalytics.jsx
@@ -31,19 +31,29 @@ export default class GoogleAnalytics extends React.Component {
     const isDifferentSearch = search !== prevLocation.collectionFilter
 
     if (analyticsInitiated && (isDifferentPathname || isDifferentSearch)) {
-      this.logPageChange(pathname, search)
+      const profileNames = analyticsConfig.profiles
+        ? analyticsConfig.profiles.map(profile => {
+            if (profile.gaOptions && profile.gaOptions.name) {
+              return profile.gaOptions.name
+            }
+          })
+        : []
+      this.logPageChange(pathname, search, profileNames)
     }
   }
 
-  logPageChange(pathname, search = '') {
+  logPageChange(pathname, search = '', profileNames) {
     const page = pathname + search
     const {location} = window
-    ReactGA.set({
-      page,
-      location: `${location.origin}${page}`,
-      ...this.props.options,
-    })
-    ReactGA.pageview(page)
+    ReactGA.set(
+      {
+        page,
+        location: `${location.origin}${page}`,
+        ...this.props.options,
+      },
+      profileNames
+    )
+    ReactGA.pageview(page, profileNames)
   }
 
   render() {

--- a/client/src/components/analytics/GoogleAnalytics.jsx
+++ b/client/src/components/analytics/GoogleAnalytics.jsx
@@ -31,13 +31,14 @@ export default class GoogleAnalytics extends React.Component {
     const isDifferentSearch = search !== prevLocation.collectionFilter
 
     if (analyticsInitiated && (isDifferentPathname || isDifferentSearch)) {
-      const profileNames = analyticsConfig.profiles
-        ? analyticsConfig.profiles.map(profile => {
-            if (profile.gaOptions && profile.gaOptions.name) {
-              return profile.gaOptions.name
-            }
-          })
-        : []
+      let profileNames = []
+      if (analyticsConfig.profiles) {
+        analyticsConfig.profiles.forEach(profile => {
+          if (profile.gaOptions && profile.gaOptions.name) {
+            profileNames.push(profile.gaOptions.name)
+          }
+        })
+      }
       this.logPageChange(pathname, search, profileNames)
     }
   }

--- a/docs/deployment/feature-toggles.md
+++ b/docs/deployment/feature-toggles.md
@@ -67,17 +67,20 @@ Unfortunately, we don’t currently have a way to dynamically determine where th
 
 There are two *new* sections to the search API UI config YML.
 
-1. Google Analytics can be configured by replacing the following parts with the appropriate IDs for the test and prod environments. See Google Analytics documentation for more details.
-    - `trackingId: 'UA-XXXXXXXXX-X'`
-    - `userId: XXXXXXXXX`
 1. If the cart feature is desired, simply add the `enableFeatureToggles` config section as seen below. Without it, the UI will default to not showing a cart feature.
+
+1. Google Analytics can be configured by replacing the following parts with the appropriate IDs for the test and prod environments. When using multiple trackers, you **must** provide a name for additional trackers. There can only be one default (without a name), and the one without a name will only receive updates depending on `reactGaOptions.alwaysSendToDefaultTracker`. See Google Analytics and react-ga documentation for more details.   
+    - `trackingId: 'UA-XXXXXXXXX-X'`
+    - `name: XXXXXXXXX`
+    
+
 ```
  ui:
     googleAnalytics:
       profiles:
         - trackingId: 'UA-XXXXXXXXX-X'
           gaOptions:
-            userId: XXXXXXXXX
+            name: XXXXXXXXX
       reactGaOptions:
         alwaysSendToDefaultTracker: false
     enabledFeatureToggles:

--- a/helm/api-search/values.yaml
+++ b/helm/api-search/values.yaml
@@ -33,7 +33,7 @@ config: |-
       profiles:
         - trackingId: 'UA-127993388-1'
           gaOptions:
-            userId: 127993388
+            name: 127993388
       reactGaOptions:
         alwaysSendToDefaultTracker: false
     enabledFeatureToggles:


### PR DESCRIPTION
Before these changes, specifying multiple tracking IDs would only send the first one under profiles. This is because additional trackers must be named and the one that is unnamed is the 'default', as in `reactGaOptions.alwaysSendToDefaultTracker`. 

These changes allow for multiple trackers. I also updated the documentation. 

To review this and debug google analytics in general, I highly recommend the google analytics debugger chrome extension. 
