### PR TITLE
Tweak 508 statement based on work finished for planned release.

### DIFF
--- a/client/src/components/about/About.jsx
+++ b/client/src/components/about/About.jsx
@@ -86,10 +86,10 @@ export default class About extends React.Component {
               amended in 1998.
             </p>
             <p>
-              We have completed a 3rd party review that confirms the site is
-              Level AA accessibility for all of our features. We will continue
-              to make improvements across our entire site aiming for AAA
-              compliance where possible.
+              We have completed a 3rd party review that confirms the site meets
+              Level AA accessibility requirements for all of our features, save
+              one in development. We will continue to make improvements across
+              our entire site aiming for AAA compliance where possible.
             </p>
             <p>
               If you experience any challenges while accessing parts of our


### PR DESCRIPTION
Had a discussion with Dave re: release timing and work left to do on last 508 story. We decided cutting a release and our other work should be wrapped up now, and we need a little more time to finish up the 508 stuff to our satisfaction. So we're updating the 508 statement to reflect the current work completed, and can update it again once that epic is actually done.