### PR TITLE
972 default kafka indexing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,9 @@ restoreCache: &restoreCache
   # Download and cache dependencies
   restore_cache:
       keys:
-      - onestop-cache-v3-{{ checksum "build.gradle" }}
+      - onestop-cache-v4-{{ checksum "build.gradle" }}
       # fallback to using the latest cache if no exact match is found
-      - onestop-cache-v3-
+      - onestop-cache-v4-
 
 saveCache: &saveCache
   save_cache:
@@ -34,7 +34,7 @@ saveCache: &saveCache
         # - buildSrc/.gradle
         - client/.gradle
         - client/node_modules
-      key: onestop-cache-v3-{{ checksum "build.gradle" }}
+      key: onestop-cache-v4-{{ checksum "build.gradle" }}
 
 attachWorkspace: &attachWorkspace
   - attach_workspace:

--- a/api-metadata/build.gradle
+++ b/api-metadata/build.gradle
@@ -28,19 +28,15 @@ dependencies {
   testImplementation(project(path: ':elastic-common', configuration: 'testElastic'))
 
   // Kafka dependencies for connecting with PSI
-  implementation('com.github.cedardevs.schemas:schemas-core:16-defaultParser-SNAPSHOT')
-  implementation('com.github.cedardevs.schemas:schemas-parse:16-defaultParser-SNAPSHOT')
-  implementation('com.github.cedardevs.schemas:schemas-analyze:16-defaultParser-SNAPSHOT')
-//  implementation('com.github.cedardevs.schemas:schemas-core:0.4.0')
-//  implementation('com.github.cedardevs.schemas:schemas-parse:0.4.0')
-//  implementation('com.github.cedardevs.schemas:schemas-analyze:0.4.0')
+  implementation("com.github.cedardevs.schemas:schemas-core:${project.schemasVersion}")
+  implementation("com.github.cedardevs.schemas:schemas-parse:${project.schemasVersion}")
+  implementation("com.github.cedardevs.schemas:schemas-analyze:${project.schemasVersion}")
   implementation("io.confluent:kafka-streams-avro-serde:5.2.1")
 
   implementation("org.apache.kafka:kafka-clients:2.2.1")
   implementation("org.springframework.kafka:spring-kafka:2.2.8.RELEASE")
 
-  testImplementation("com.github.cedardevs.schemas:schemas-core:16-defaultParser-SNAPSHOT:test")
-  //  testImplementation("com.github.cedardevs.schemas:schemas-core:0.4.0:test")
+  testImplementation("com.github.cedardevs.schemas:schemas-core:${project.schemasVersion}:test")
 
   testImplementation("io.confluent:kafka-schema-registry:5.2.1")
   testImplementation("io.confluent:kafka-schema-registry:5.2.1:tests")

--- a/api-metadata/build.gradle
+++ b/api-metadata/build.gradle
@@ -36,7 +36,7 @@ dependencies {
   implementation("org.apache.kafka:kafka-clients:2.2.1")
   implementation("org.springframework.kafka:spring-kafka:2.2.8.RELEASE")
 
-  testImplementation("com.github.cedardevs.schemas:schemas-core:0.3.0:test")
+  testImplementation("com.github.cedardevs.schemas:schemas-core:16-defaultParser-SNAPSHOT:test")
 
   testImplementation("io.confluent:kafka-schema-registry:5.2.1")
   testImplementation("io.confluent:kafka-schema-registry:5.2.1:tests")

--- a/api-metadata/build.gradle
+++ b/api-metadata/build.gradle
@@ -31,12 +31,16 @@ dependencies {
   implementation('com.github.cedardevs.schemas:schemas-core:16-defaultParser-SNAPSHOT')
   implementation('com.github.cedardevs.schemas:schemas-parse:16-defaultParser-SNAPSHOT')
   implementation('com.github.cedardevs.schemas:schemas-analyze:16-defaultParser-SNAPSHOT')
+//  implementation('com.github.cedardevs.schemas:schemas-core:0.4.0')
+//  implementation('com.github.cedardevs.schemas:schemas-parse:0.4.0')
+//  implementation('com.github.cedardevs.schemas:schemas-analyze:0.4.0')
   implementation("io.confluent:kafka-streams-avro-serde:5.2.1")
 
   implementation("org.apache.kafka:kafka-clients:2.2.1")
   implementation("org.springframework.kafka:spring-kafka:2.2.8.RELEASE")
 
   testImplementation("com.github.cedardevs.schemas:schemas-core:16-defaultParser-SNAPSHOT:test")
+  //  testImplementation("com.github.cedardevs.schemas:schemas-core:0.4.0:test")
 
   testImplementation("io.confluent:kafka-schema-registry:5.2.1")
   testImplementation("io.confluent:kafka-schema-registry:5.2.1:tests")

--- a/api-metadata/build.gradle
+++ b/api-metadata/build.gradle
@@ -28,9 +28,9 @@ dependencies {
   testImplementation(project(path: ':elastic-common', configuration: 'testElastic'))
 
   // Kafka dependencies for connecting with PSI
-  implementation('com.github.cedardevs.schemas:schemas-core:0.3.0')
-  implementation('com.github.cedardevs.schemas:schemas-parse:0.3.0')
-  implementation('com.github.cedardevs.schemas:schemas-analyze:0.3.0')
+  implementation('com.github.cedardevs.schemas:schemas-core:16-defaultParser-SNAPSHOT')
+  implementation('com.github.cedardevs.schemas:schemas-parse:16-defaultParser-SNAPSHOT')
+  implementation('com.github.cedardevs.schemas:schemas-analyze:16-defaultParser-SNAPSHOT')
   implementation("io.confluent:kafka-streams-avro-serde:5.2.1")
 
   implementation("org.apache.kafka:kafka-clients:2.2.1")

--- a/api-metadata/src/integrationTest/groovy/org/cedar/onestop/api/metadata/MigrationIntegrationTest.groovy
+++ b/api-metadata/src/integrationTest/groovy/org/cedar/onestop/api/metadata/MigrationIntegrationTest.groovy
@@ -9,7 +9,7 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.serialization.StringSerializer
 import org.cedar.onestop.api.metadata.service.ETLService
 import org.cedar.onestop.api.metadata.service.ElasticsearchService
-import org.cedar.onestop.api.metadata.service.InventoryManagerToOneStopUtil
+import org.cedar.onestop.api.metadata.service.Indexer
 import org.cedar.onestop.elastic.common.ElasticsearchConfig
 import org.cedar.schemas.avro.psi.ParsedRecord
 import org.springframework.beans.factory.annotation.Autowired
@@ -99,14 +99,14 @@ class MigrationIntegrationTest extends Specification {
     ])
 
     String collectionXml = ClassLoader.systemClassLoader.getResourceAsStream('test/data/xml/COOPS/C1.xml').text
-    ParsedRecord parsedCollection = InventoryManagerToOneStopUtil.xmlToParsedRecord(collectionXml).parsedRecord
+    ParsedRecord parsedCollection = Indexer.xmlToParsedRecord(collectionXml).parsedRecord
     String collectionKey1 = 'api_ingest_ABC'
     String collectionKey2 = 'kafka_ingest_XYZ'
     ProducerRecord collectionRecord = new ProducerRecord(collectionTopic, collectionKey1, parsedCollection)
     ProducerRecord collectionRecordUpdate = new ProducerRecord(collectionTopic, collectionKey2, parsedCollection)
 
     String granuleXml = ClassLoader.systemClassLoader.getResourceAsStream('test/data/xml/COOPS/G1.xml').text
-    ParsedRecord parsedGranule = InventoryManagerToOneStopUtil.xmlToParsedRecord(granuleXml).parsedRecord
+    ParsedRecord parsedGranule = Indexer.xmlToParsedRecord(granuleXml).parsedRecord
     String granuleKey1 = 'api_ingest_123'
     String granuleKey2  = 'kafka_ingest_789'
     ProducerRecord granuleRecord = new ProducerRecord(granuleTopic, granuleKey1, parsedGranule)

--- a/api-metadata/src/main/groovy/org.cedar.onestop.api.metadata/service/Indexer.groovy
+++ b/api-metadata/src/main/groovy/org.cedar.onestop.api.metadata/service/Indexer.groovy
@@ -24,6 +24,7 @@ class Indexer {
     def titles = analysis?.titles
     def identification = analysis?.identification
     def temporal = analysis?.temporalBounding
+    def spatial = analysis?.spatialBounding
 
     def failure = [title: 'Invalid record']
     List<String> details = []
@@ -64,6 +65,9 @@ class Indexer {
     }
     if (temporal && temporal.beginDescriptor != UNDEFINED && temporal.endDescriptor != UNDEFINED && temporal.instantDescriptor == INVALID) {
       details << "Invalid instant-only date"
+    }
+    if (spatial && spatial.spatialBoundingExists && !spatial.isValid) {
+      details << "Invalid geoJSON for spatial bounding"
     }
     if (details.size() > 0 ) {
       log.info("INVALID RECORD [ $id ]. VALIDATION FAILURES:  $details ")

--- a/api-metadata/src/main/groovy/org.cedar.onestop.api.metadata/service/Indexer.groovy
+++ b/api-metadata/src/main/groovy/org.cedar.onestop.api.metadata/service/Indexer.groovy
@@ -25,6 +25,7 @@ class Indexer {
     def identification = analysis?.identification
     def temporal = analysis?.temporalBounding
     def spatial = analysis?.spatialBounding
+    def links = analysis?.dataAccess
 
     def failure = [title: 'Invalid record']
     List<String> details = []
@@ -68,6 +69,9 @@ class Indexer {
     }
     if (spatial && spatial.spatialBoundingExists && !spatial.isValid) {
       details << "Invalid geoJSON for spatial bounding"
+    }
+    if (messageMap.type == RecordType.granule && links && !links.dataAccessExists) {
+      details << "Granule record with no data access available"
     }
     if (details.size() > 0 ) {
       log.info("INVALID RECORD [ $id ]. VALIDATION FAILURES:  $details ")

--- a/api-metadata/src/main/groovy/org.cedar.onestop.api.metadata/service/Indexer.groovy
+++ b/api-metadata/src/main/groovy/org.cedar.onestop.api.metadata/service/Indexer.groovy
@@ -16,7 +16,7 @@ import java.time.temporal.ChronoUnit
 import static org.cedar.schemas.avro.psi.ValidDescriptor.*
 
 @Slf4j
-class InventoryManagerToOneStopUtil {
+class Indexer {
 
   static Map validateMessage(String id, ParsedRecord messageMap) {
     def discovery = messageMap?.discovery

--- a/api-metadata/src/main/groovy/org.cedar.onestop.api.metadata/service/Indexer.groovy
+++ b/api-metadata/src/main/groovy/org.cedar.onestop.api.metadata/service/Indexer.groovy
@@ -32,31 +32,43 @@ class Indexer {
 
     // Validate record
     if (discovery == null) {
+      // FIXME Is this possible anymore with DefaultParser?
       details << "Missing discovery metadata"
     }
     if (analysis == null) {
+      // FIXME Is this possible anymore with DefaultParser?
       details << "Missing analysis metadata"
     }
     if (titles == null) {
+      // FIXME Only null if Discovery & Analysis was null -- actually required?
       details << "Missing title analysis"
     }
     if (identification == null) {
+      // FIXME Only null if Discovery & Analysis was null -- actually required?
       details << "Missing identification analysis"
     }
     if (temporal == null) {
+      // FIXME Only null if Discovery & Analysis was null -- actually required?
       details << "Missing temporal analysis"
     }
+
+    ///////////
+    // FIXME -- cleanup: below should never be checked if no Discovery & no Analysis
+    ///////////
+
     if (identification && (!identification?.fileIdentifierExists && !identification?.doiExists)) {
       details << "Missing identifier - record contains neither a fileIdentifier nor a DOI"
     }
-    if (messageMap.type == RecordType.collection && (identification && identification?.parentIdentifierExists)) {
-      details << "Invalid record: a collection cannot contain a parentIdentifier"
-    }
+    // FIXME -- suddenly not true:
+//    if (messageMap.type == RecordType.collection && (identification && identification?.parentIdentifierExists)) {
+//      details << "Invalid record: a collection cannot contain a parentIdentifier"
+//    }
+    // FIXME -- logic has changed
+//    if (discovery && identification && discovery.hierarchyLevelName == 'granule' && !identification.parentIdentifierExists) {
+//      details << "Mismatch between metadata type and identifiers detected"
+//    }
     if (titles && !titles.titleExists) {
       details << "Missing title"
-    }
-    if (discovery && identification && discovery.hierarchyLevelName == 'granule' && !identification.parentIdentifierExists) {
-      details << "Mismatch between metadata type and identifiers detected"
     }
     if (temporal && temporal.beginDescriptor == INVALID) {
       details << "Invalid beginDate"
@@ -69,9 +81,6 @@ class Indexer {
     }
     if (spatial && spatial.spatialBoundingExists && !spatial.isValid) {
       details << "Invalid geoJSON for spatial bounding"
-    }
-    if (messageMap.type == RecordType.granule && links && !links.dataAccessExists) {
-      details << "Granule record with no data access available"
     }
     if (details.size() > 0 ) {
       log.info("INVALID RECORD [ $id ]. VALIDATION FAILURES:  $details ")

--- a/api-metadata/src/main/groovy/org.cedar.onestop.api.metadata/service/Indexer.groovy
+++ b/api-metadata/src/main/groovy/org.cedar.onestop.api.metadata/service/Indexer.groovy
@@ -88,7 +88,7 @@ class Indexer {
       String hierarchyLevelName = discovery.hierarchyLevelName
 
       RecordType type
-      if(hierarchyLevelName != 'granule') {
+      if(hierarchyLevelName == null || hierarchyLevelName != 'granule') {
         type = RecordType.collection
       }
       else {
@@ -129,6 +129,7 @@ class Indexer {
 
     Map discoveryMap = AvroUtils.avroToMap(discovery, true)
 
+    // FIXME this is not how we set this...
     discoveryMap.type = discoveryMap?.parentIdentifier ?
         ElasticsearchConfig.TYPE_GRANULE : ElasticsearchConfig.TYPE_COLLECTION
 

--- a/api-metadata/src/main/groovy/org.cedar.onestop.api.metadata/service/Indexer.groovy
+++ b/api-metadata/src/main/groovy/org.cedar.onestop.api.metadata/service/Indexer.groovy
@@ -19,6 +19,8 @@ class Indexer {
 
   static Map validateMessage(String id, ParsedRecord messageMap) {
 
+    // FIXME Improve testability of failures by creating an Enum for invalid messages
+
     def failure = [title: 'Invalid record']
     List<String> details = []
 

--- a/api-metadata/src/main/groovy/org.cedar.onestop.api.metadata/service/Indexer.groovy
+++ b/api-metadata/src/main/groovy/org.cedar.onestop.api.metadata/service/Indexer.groovy
@@ -129,8 +129,8 @@ class Indexer {
 
     Map discoveryMap = AvroUtils.avroToMap(discovery, true)
 
-    // FIXME this is not how we set this...
-    discoveryMap.type = discoveryMap?.parentIdentifier ?
+    // Records validated before getting to this point to no null record.type possible (always granule or collection)
+    discoveryMap.type = record.type == RecordType.granule ?
         ElasticsearchConfig.TYPE_GRANULE : ElasticsearchConfig.TYPE_COLLECTION
 
     // create GCMD keywords

--- a/api-metadata/src/main/groovy/org.cedar.onestop.api.metadata/service/Indexer.groovy
+++ b/api-metadata/src/main/groovy/org.cedar.onestop.api.metadata/service/Indexer.groovy
@@ -8,7 +8,6 @@ import org.cedar.schemas.avro.util.AvroUtils
 import org.cedar.schemas.analyze.Analyzers
 import org.cedar.schemas.parse.ISOParser
 import org.xml.sax.SAXException
-import org.elasticsearch.Version
 import org.cedar.onestop.elastic.common.ElasticsearchConfig
 
 import java.time.temporal.ChronoUnit
@@ -19,6 +18,7 @@ import static org.cedar.schemas.avro.psi.ValidDescriptor.*
 class Indexer {
 
   static Map validateMessage(String id, ParsedRecord messageMap) {
+
     def discovery = messageMap?.discovery
     def analysis = messageMap?.analysis
     def titles = analysis?.titles
@@ -107,7 +107,7 @@ class Indexer {
     return result
   }
 
-  static Map reformatMessageForSearch(ParsedRecord record, Version version) {
+  static Map reformatMessageForSearch(ParsedRecord record) {
     Discovery discovery = record.discovery
     Analysis analysis = record.analysis
 

--- a/api-metadata/src/main/groovy/org.cedar.onestop.api.metadata/service/KafkaConsumerService.groovy
+++ b/api-metadata/src/main/groovy/org.cedar.onestop.api.metadata/service/KafkaConsumerService.groovy
@@ -2,6 +2,7 @@ package org.cedar.onestop.api.metadata.service
 
 import groovy.util.logging.Slf4j
 import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.cedar.schemas.analyze.Analyzers
 import org.cedar.schemas.avro.psi.ParsedRecord
 import org.cedar.schemas.parse.DefaultParser
 import org.springframework.beans.factory.annotation.Autowired
@@ -32,10 +33,10 @@ class KafkaConsumerService {
     log.info("consuming message from kafka topic")
     try {
       def validRecords = records.stream()
-          .filter({ it != null })
+          .filter({ (it != null)} )
           .map({
             if(it.value().discovery == null && it.value().analysis == null) {
-              [id: it.key(), parsedRecord: DefaultParser.addDiscoveryToParsedRecord(it.value())]
+              [id: it.key(), parsedRecord: Analyzers.addAnalysis(DefaultParser.addDiscoveryToParsedRecord(it.value()))]
             }
             else {
               [id: it.key(), parsedRecord: it.value()]
@@ -43,12 +44,6 @@ class KafkaConsumerService {
            })
           .filter({Indexer.validateMessage(it.id, it.parsedRecord)?.valid})
           .collect(Collectors.toList())
-
-//      def validRecords = records.stream().filter({
-//        it != null && Indexer.validateMessage(it.key(), it.value())?.valid
-//      }).map({
-//        [id: it.key(), parsedRecord: it.value()]
-//      }).collect(Collectors.toList())
 
       if (validRecords.size() > 0) {
         metadataManagementService.loadParsedRecords(validRecords)

--- a/api-metadata/src/main/groovy/org.cedar.onestop.api.metadata/service/KafkaConsumerService.groovy
+++ b/api-metadata/src/main/groovy/org.cedar.onestop.api.metadata/service/KafkaConsumerService.groovy
@@ -31,7 +31,7 @@ class KafkaConsumerService {
     log.info("consuming message from kafka topic")
     try {
       def validRecords = records.stream().filter({
-        it != null && InventoryManagerToOneStopUtil.validateMessage(it.key(), it.value())?.valid
+        it != null && Indexer.validateMessage(it.key(), it.value())?.valid
       }).map({
         [id: it.key(), parsedRecord: it.value()]
       }).collect(Collectors.toList())

--- a/api-metadata/src/main/groovy/org.cedar.onestop.api.metadata/service/MetadataManagementService.groovy
+++ b/api-metadata/src/main/groovy/org.cedar.onestop.api.metadata/service/MetadataManagementService.groovy
@@ -61,7 +61,7 @@ class MetadataManagementService {
     }
   }
 
-  Map loadXMLdocuments(List documents){
+  Map loadXMLdocuments(List documents) {
     List<Map<String, ?>> parsedRecords = []
     List results = []
     documents.each { document ->
@@ -70,7 +70,8 @@ class MetadataManagementService {
       if (document instanceof MultipartFile) {
         fileName = document.originalFilename
         xml = document.inputStream.text
-      } else {
+      }
+      else {
         xml = document as String
       }
       Map result = [
@@ -79,19 +80,21 @@ class MetadataManagementService {
           ]
       ]
       log.info("Loading XML document ${fileName ? fileName.toString() : '(no filename provided)'}")
-      Map parseResult = InventoryManagerToOneStopUtil.xmlToParsedRecord(xml)
+      Map parseResult = Indexer.xmlToParsedRecord(xml)
       if(parseResult?.parsedRecord){
-        Map validationResult = InventoryManagerToOneStopUtil.validateMessage(fileName, parseResult.parsedRecord)
+        Map validationResult = Indexer.validateMessage(fileName, parseResult.parsedRecord)
         if(!validationResult?.title){
           log.debug("Validation success: $fileName is valid")
           parsedRecords << [filename:fileName, parsedRecord: parseResult.parsedRecord as ParsedRecord]
-        }else{
+        }
+        else{
           log.warn("Validation failed: $fileName is invalid. Cause: ${validationResult.details} ")
           validationResult.status = HttpStatus.BAD_REQUEST.value()
           result.meta.error = validationResult
           results << result
         }
-      }else {
+      }
+      else {
         String title = "${parseResult?.error?.title ?: 'Parse error'}"
         String parseErrorDetails = "${parseResult?.error?.detail ?: "Unable to generate a ParsedRecord from xml "}"
         result.meta = [error: [title: title, detail: parseErrorDetails, status: HttpStatus.BAD_REQUEST.value()]]
@@ -118,7 +121,7 @@ class MetadataManagementService {
 
       try {
         log.debug("Reformating record for search with [id: $id, filename: $filename]")
-        Map source = InventoryManagerToOneStopUtil.reformatMessageForSearch(avroRecord, esService.version)
+        Map source = Indexer.reformatMessageForSearch(avroRecord, esService.version)
         String fileId = source.fileIdentifier as String
         String doi = source.doi as String
 

--- a/api-metadata/src/main/groovy/org.cedar.onestop.api.metadata/service/MetadataManagementService.groovy
+++ b/api-metadata/src/main/groovy/org.cedar.onestop.api.metadata/service/MetadataManagementService.groovy
@@ -121,7 +121,7 @@ class MetadataManagementService {
 
       try {
         log.debug("Reformating record for search with [id: $id, filename: $filename]")
-        Map source = Indexer.reformatMessageForSearch(avroRecord, esService.version)
+        Map source = Indexer.reformatMessageForSearch(avroRecord)
         String fileId = source.fileIdentifier as String
         String doi = source.doi as String
 

--- a/api-metadata/src/test/groovy/org/cedar/onestop/api/metadata/service/IndexerTest.groovy
+++ b/api-metadata/src/test/groovy/org/cedar/onestop/api/metadata/service/IndexerTest.groovy
@@ -310,13 +310,7 @@ class IndexerTest extends Specification {
     stagingDoc.description == 'Wall of overly detailed, super informative, extra important text.'
     // Deep equality check
     generatedKeywords == expectedKeywords
-    //todo confirm this is what we want
     stagingDoc.accessionValues == []
-//    stagingDoc.accessionValues == [
-//        '0038924',
-//        '0038947',
-//        '0038970'
-//    ] as Set
     stagingDoc.topicCategories == ['environment', 'oceans']
     stagingDoc.gcmdLocations == [
         'Geographic Region',
@@ -358,9 +352,7 @@ class IndexerTest extends Specification {
             ]
         ]
     ] as String
-//    stagingDoc.isGlobal == true
-    //todo confirm change from metadataParser
-    stagingDoc.isGlobal == false
+    stagingDoc.isGlobal == true
     stagingDoc.acquisitionInstruments == [
         [
             instrumentIdentifier : 'SII > Super Important Instrument',

--- a/api-metadata/src/test/groovy/org/cedar/onestop/api/metadata/service/IndexerTest.groovy
+++ b/api-metadata/src/test/groovy/org/cedar/onestop/api/metadata/service/IndexerTest.groovy
@@ -11,7 +11,7 @@ import spock.lang.Unroll
 import static org.cedar.schemas.avro.util.TemporalTestData.situations
 
 @Unroll
-class InventoryManagerToOneStopUtilTest extends Specification {
+class IndexerTest extends Specification {
 
   def inputStream = ClassLoader.systemClassLoader.getResourceAsStream('example-record-avro.json')
   def inputRecord = AvroUtils.<ParsedRecord> jsonToAvro(inputStream, ParsedRecord.classSchema)
@@ -160,7 +160,7 @@ class InventoryManagerToOneStopUtilTest extends Specification {
 
   def "Create GCMD keyword lists"() {
     when:
-    Map parsedKeywords = InventoryManagerToOneStopUtil.createGcmdKeyword(inputRecord.discovery)
+    Map parsedKeywords = Indexer.createGcmdKeyword(inputRecord.discovery)
 
     then:
     parsedKeywords.gcmdScienceServices == expectedGcmdKeywords.gcmdScienceServices
@@ -181,7 +181,7 @@ class InventoryManagerToOneStopUtilTest extends Specification {
 
   def "Create contacts, publishers and creators from responsibleParties"() {
     when:
-    Map partiesMap = InventoryManagerToOneStopUtil.parseResponsibleParties(inputRecord.discovery.responsibleParties)
+    Map partiesMap = Indexer.parseResponsibleParties(inputRecord.discovery.responsibleParties)
 
     then:
     partiesMap.contacts == expectedResponsibleParties.contacts
@@ -191,7 +191,7 @@ class InventoryManagerToOneStopUtilTest extends Specification {
 
   def "When #situation.description, expected temporal bounding generated"() {
     when:
-    def newTimeMetadata = InventoryManagerToOneStopUtil.readyDatesForSearch(situation.bounding, situation.analysis)
+    def newTimeMetadata = Indexer.readyDatesForSearch(situation.bounding, situation.analysis)
 
     then:
     newTimeMetadata == expectedResult
@@ -213,7 +213,7 @@ class InventoryManagerToOneStopUtilTest extends Specification {
     when:
 
     // TODO: test both ES6+ and ES5- ?
-    def result = InventoryManagerToOneStopUtil.reformatMessageForSearch(inputRecord, Version.V_6_1_2)
+    def result = Indexer.reformatMessageForSearch(inputRecord, Version.V_6_1_2)
 
     then:
 
@@ -236,7 +236,7 @@ class InventoryManagerToOneStopUtilTest extends Specification {
 
   def "valid message passes validation check"() {
     expect:
-    InventoryManagerToOneStopUtil.validateMessage('dummy id', inputRecord)
+    Indexer.validateMessage('dummy id', inputRecord)
   }
 
   def "invalid message fails validation check"() {
@@ -266,7 +266,7 @@ class InventoryManagerToOneStopUtilTest extends Specification {
         .build()
 
     expect:
-    !InventoryManagerToOneStopUtil.validateMessage('dummy id', record)?.valid
+    !Indexer.validateMessage('dummy id', record)?.valid
   }
 
   def 'xml to ParsedRecord to staging doc (test from old MetadataParserSpec)'(){
@@ -358,10 +358,10 @@ class InventoryManagerToOneStopUtilTest extends Specification {
     def document = ClassLoader.systemClassLoader.getResourceAsStream("test-iso-metadata.xml").text
 
     when:
-    Map parsedXML = InventoryManagerToOneStopUtil.xmlToParsedRecord(document)
-    Map validationResult = InventoryManagerToOneStopUtil.validateMessage('parsed_record_test_id', parsedXML.parsedRecord)
+    Map parsedXML = Indexer.xmlToParsedRecord(document)
+    Map validationResult = Indexer.validateMessage('parsed_record_test_id', parsedXML.parsedRecord)
     Map discoveryMap = AvroUtils.avroToMap(parsedXML.parsedRecord.discovery, true)
-    Map stagingDoc = InventoryManagerToOneStopUtil.reformatMessageForSearch(parsedXML.parsedRecord, Version.V_6_1_2)
+    Map stagingDoc = Indexer.reformatMessageForSearch(parsedXML.parsedRecord, Version.V_6_1_2)
     def generatedKeywords = JsonOutput.toJson(stagingDoc.keywords)
 
     then:
@@ -600,7 +600,7 @@ class InventoryManagerToOneStopUtilTest extends Specification {
 
     when: 'you attempt to parse the xml'
 
-    def parsedXml = InventoryManagerToOneStopUtil.xmlToParsedRecord(document)
+    def parsedXml = Indexer.xmlToParsedRecord(document)
 
     then: 'we throw an exception instead of parsing attack-vector xml'
     parsedXml.error.title == 'Load request failed due to malformed XML.'
@@ -612,9 +612,9 @@ class InventoryManagerToOneStopUtilTest extends Specification {
     def document = ClassLoader.systemClassLoader.getResourceAsStream("test-iso-metadata.xml").text
 
     when:
-    Map parsedXML = InventoryManagerToOneStopUtil.xmlToParsedRecord(document)
+    Map parsedXML = Indexer.xmlToParsedRecord(document)
 
-    Map stagingDoc = InventoryManagerToOneStopUtil.reformatMessageForSearch(parsedXML.parsedRecord, Version.V_6_1_2)
+    Map stagingDoc = Indexer.reformatMessageForSearch(parsedXML.parsedRecord, Version.V_6_1_2)
 
     then:
     stagingDoc.temporalBounding == [
@@ -630,9 +630,9 @@ class InventoryManagerToOneStopUtilTest extends Specification {
     def document = ClassLoader.systemClassLoader.getResourceAsStream("test-iso-paleo-dates-metadata.xml").text
 
     when:
-    Map parsedXML = InventoryManagerToOneStopUtil.xmlToParsedRecord(document)
+    Map parsedXML = Indexer.xmlToParsedRecord(document)
 
-    Map stagingDoc = InventoryManagerToOneStopUtil.reformatMessageForSearch(parsedXML.parsedRecord, Version.V_6_1_2)
+    Map stagingDoc = Indexer.reformatMessageForSearch(parsedXML.parsedRecord, Version.V_6_1_2)
 
     then:
     stagingDoc.temporalBounding == [
@@ -648,9 +648,9 @@ class InventoryManagerToOneStopUtilTest extends Specification {
     def document = ClassLoader.systemClassLoader.getResourceAsStream("test-iso-no-timezone-dates-metadata.xml").text
 
     when:
-    Map parsedXML = InventoryManagerToOneStopUtil.xmlToParsedRecord(document)
+    Map parsedXML = Indexer.xmlToParsedRecord(document)
 
-    Map stagingDoc = InventoryManagerToOneStopUtil.reformatMessageForSearch(parsedXML.parsedRecord, Version.V_6_1_2)
+    Map stagingDoc = Indexer.reformatMessageForSearch(parsedXML.parsedRecord, Version.V_6_1_2)
 
     then:
     stagingDoc.temporalBounding == [
@@ -666,8 +666,8 @@ class InventoryManagerToOneStopUtilTest extends Specification {
     def document = ClassLoader.systemClassLoader.getResourceAsStream("test-iso-invalid-dates-metadata.xml").text
 
     when:
-    Map parsedXML = InventoryManagerToOneStopUtil.xmlToParsedRecord(document)
-    Map stagingDoc = InventoryManagerToOneStopUtil.reformatMessageForSearch(parsedXML.parsedRecord, Version.V_6_1_2)
+    Map parsedXML = Indexer.xmlToParsedRecord(document)
+    Map stagingDoc = Indexer.reformatMessageForSearch(parsedXML.parsedRecord, Version.V_6_1_2)
 
     then:
     parsedXML.parsedRecord.analysis.temporalBounding.beginDescriptor as String == 'INVALID'

--- a/api-metadata/src/test/groovy/org/cedar/onestop/api/metadata/service/IndexerTest.groovy
+++ b/api-metadata/src/test/groovy/org/cedar/onestop/api/metadata/service/IndexerTest.groovy
@@ -3,7 +3,6 @@ package org.cedar.onestop.api.metadata.service
 import groovy.json.JsonOutput
 import org.cedar.schemas.avro.psi.*
 import org.cedar.schemas.avro.util.AvroUtils
-import org.elasticsearch.Version
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -211,13 +210,9 @@ class IndexerTest extends Specification {
 
   def "new record is ready for onestop"() {
     when:
-
-    // TODO: test both ES6+ and ES5- ?
-    def result = Indexer.reformatMessageForSearch(inputRecord, Version.V_6_1_2)
+    def result = Indexer.reformatMessageForSearch(inputRecord)
 
     then:
-
-    // TODO: conditional based on ES6+ and ES5-?
     result.serviceLinks == []
     result.accessionValues == []
 
@@ -361,7 +356,7 @@ class IndexerTest extends Specification {
     Map parsedXML = Indexer.xmlToParsedRecord(document)
     Map validationResult = Indexer.validateMessage('parsed_record_test_id', parsedXML.parsedRecord)
     Map discoveryMap = AvroUtils.avroToMap(parsedXML.parsedRecord.discovery, true)
-    Map stagingDoc = Indexer.reformatMessageForSearch(parsedXML.parsedRecord, Version.V_6_1_2)
+    Map stagingDoc = Indexer.reformatMessageForSearch(parsedXML.parsedRecord)
     def generatedKeywords = JsonOutput.toJson(stagingDoc.keywords)
 
     then:
@@ -614,7 +609,7 @@ class IndexerTest extends Specification {
     when:
     Map parsedXML = Indexer.xmlToParsedRecord(document)
 
-    Map stagingDoc = Indexer.reformatMessageForSearch(parsedXML.parsedRecord, Version.V_6_1_2)
+    Map stagingDoc = Indexer.reformatMessageForSearch(parsedXML.parsedRecord)
 
     then:
     stagingDoc.temporalBounding == [
@@ -632,7 +627,7 @@ class IndexerTest extends Specification {
     when:
     Map parsedXML = Indexer.xmlToParsedRecord(document)
 
-    Map stagingDoc = Indexer.reformatMessageForSearch(parsedXML.parsedRecord, Version.V_6_1_2)
+    Map stagingDoc = Indexer.reformatMessageForSearch(parsedXML.parsedRecord)
 
     then:
     stagingDoc.temporalBounding == [
@@ -650,7 +645,7 @@ class IndexerTest extends Specification {
     when:
     Map parsedXML = Indexer.xmlToParsedRecord(document)
 
-    Map stagingDoc = Indexer.reformatMessageForSearch(parsedXML.parsedRecord, Version.V_6_1_2)
+    Map stagingDoc = Indexer.reformatMessageForSearch(parsedXML.parsedRecord)
 
     then:
     stagingDoc.temporalBounding == [
@@ -667,7 +662,7 @@ class IndexerTest extends Specification {
 
     when:
     Map parsedXML = Indexer.xmlToParsedRecord(document)
-    Map stagingDoc = Indexer.reformatMessageForSearch(parsedXML.parsedRecord, Version.V_6_1_2)
+    Map stagingDoc = Indexer.reformatMessageForSearch(parsedXML.parsedRecord)
 
     then:
     parsedXML.parsedRecord.analysis.temporalBounding.beginDescriptor as String == 'INVALID'

--- a/api-metadata/src/test/groovy/org/cedar/onestop/api/metadata/service/IndexerTest.groovy
+++ b/api-metadata/src/test/groovy/org/cedar/onestop/api/metadata/service/IndexerTest.groovy
@@ -165,8 +165,8 @@ class IndexerTest extends Specification {
     Indexer.validateMessage('dummy id', inputRecord)
   }
 
+  // FIXME verify each validation check in isolation
   def "invalid message fails validation check"() {
-    // FIXME not really checking all the validation steps here
     given:
     def titleAnalysis = TitleAnalysis.newBuilder(inputRecord.analysis.titles)
         .setTitleExists(false)

--- a/api-metadata/src/test/groovy/org/cedar/onestop/api/metadata/service/IndexerTest.groovy
+++ b/api-metadata/src/test/groovy/org/cedar/onestop/api/metadata/service/IndexerTest.groovy
@@ -542,10 +542,10 @@ class IndexerTest extends Specification {
 
     where:
     type                  | path                             | situation
-    RecordType.granule    | 'test-iso-granule-type.xml'      | 'hlm is granule and pid present'
-    RecordType.collection | 'test-iso-collection-type-1.xml' | 'hlm is present but not granule'
-    RecordType.collection | 'test-iso-collection-type-2.xml' | 'hlm is null'
-    null                  | 'test-iso-error-type.xml'        | 'hlm is granule but no pid present'
+    RecordType.granule    | 'test-iso-granule-type.xml'      | 'hln is granule and pid present'
+    RecordType.collection | 'test-iso-collection-type-1.xml' | 'hln is present but not granule'
+    RecordType.collection | 'test-iso-collection-type-2.xml' | 'hln is null'
+    null                  | 'test-iso-error-type.xml'        | 'hln is granule but no pid present'
   }
 
 

--- a/api-metadata/src/test/groovy/org/cedar/onestop/api/metadata/service/LoadKafkaMsgServiceTest.groovy
+++ b/api-metadata/src/test/groovy/org/cedar/onestop/api/metadata/service/LoadKafkaMsgServiceTest.groovy
@@ -71,11 +71,14 @@ class LoadKafkaMsgServiceTest extends Specification {
     def inputValue = AvroUtils.<ParsedRecord> jsonToAvro(inputStream, ParsedRecord.classSchema)
     def inputRecord = new ConsumerRecord(testCollectionTopic, 0 , 0, inputKey, inputValue)
 
+    def expectedOutputStream = ClassLoader.systemClassLoader.getResourceAsStream('parsed-record-with-default-discovery.json')
+    def expectedOutputValue = AvroUtils.<ParsedRecord> jsonToAvro(expectedOutputStream, ParsedRecord.classSchema)
+
     when:
     consumerService.listen([inputRecord])
 
     then:
-    0 * mockMetadataService.loadParsedRecords([[id: inputKey, parsedRecord: inputValue]])
+    1 * mockMetadataService.loadParsedRecords([[id: inputKey, parsedRecord: expectedOutputValue]])
   }
 
 }

--- a/api-metadata/src/test/groovy/org/cedar/onestop/api/metadata/service/LoadKafkaMsgServiceTest.groovy
+++ b/api-metadata/src/test/groovy/org/cedar/onestop/api/metadata/service/LoadKafkaMsgServiceTest.groovy
@@ -75,7 +75,7 @@ class LoadKafkaMsgServiceTest extends Specification {
     consumerService.listen([inputRecord])
 
     then:
-    1 * mockMetadataService.loadParsedRecords([[id: inputKey, parsedRecord: inputValue]])
+    0 * mockMetadataService.loadParsedRecords([[id: inputKey, parsedRecord: inputValue]])
   }
 
 }

--- a/api-metadata/src/test/groovy/org/cedar/onestop/api/metadata/service/LoadKafkaMsgServiceTest.groovy
+++ b/api-metadata/src/test/groovy/org/cedar/onestop/api/metadata/service/LoadKafkaMsgServiceTest.groovy
@@ -64,4 +64,18 @@ class LoadKafkaMsgServiceTest extends Specification {
     1 * mockMetadataService.loadParsedRecords({ it.size() == 1 && it[0].parsedRecord == validRecord.value() })
   }
 
+  def "appends default index-ready Discovery and Analysis to ParsedRecord"() {
+    given:
+    def inputKey = 'default123'
+    def inputStream = ClassLoader.systemClassLoader.getResourceAsStream('parsed-record-no-discovery-or-analysis.json')
+    def inputValue = AvroUtils.<ParsedRecord> jsonToAvro(inputStream, ParsedRecord.classSchema)
+    def inputRecord = new ConsumerRecord(testCollectionTopic, 0 , 0, inputKey, inputValue)
+
+    when:
+    consumerService.listen([inputRecord])
+
+    then:
+    1 * mockMetadataService.loadParsedRecords([[id: inputKey, parsedRecord: inputValue]])
+  }
+
 }

--- a/api-metadata/src/test/resources/parsed-record-no-discovery-or-analysis.json
+++ b/api-metadata/src/test/resources/parsed-record-no-discovery-or-analysis.json
@@ -39,12 +39,8 @@
   },
   "relationships": [
     {
-      "org.cedar.schemas.avro.psi.Relationship": {
-        "type":  {
-          "org.cedar.schemas.avro.psi.Relationship.RelationshipType": "COLLECTION"
-        },
+        "type": "COLLECTION",
         "id": "cb03311a-0ee0-4649-92d9-f8c3a28bcb29"
-      }
     }
   ],
   "errors": []

--- a/api-metadata/src/test/resources/parsed-record-no-discovery-or-analysis.json
+++ b/api-metadata/src/test/resources/parsed-record-no-discovery-or-analysis.json
@@ -39,7 +39,9 @@
   },
   "relationships": [
     {
-        "type": "COLLECTION",
+        "type": {
+          "org.cedar.schemas.avro.psi.RelationshipType": "COLLECTION"
+        },
         "id": "cb03311a-0ee0-4649-92d9-f8c3a28bcb29"
     }
   ],

--- a/api-metadata/src/test/resources/parsed-record-no-discovery-or-analysis.json
+++ b/api-metadata/src/test/resources/parsed-record-no-discovery-or-analysis.json
@@ -7,9 +7,11 @@
   "fileInformation": {
     "org.cedar.schemas.avro.psi.FileInformation": {
       "name": "testGranuleFile.nc",
-      "size": null,
+      "size": 108162440,
       "checksums": [],
-      "format": "NetCDF",
+      "format": {
+        "string": "NetCDF"
+      },
       "headers": null,
       "optionalAttributes": {}
     }
@@ -25,21 +27,21 @@
       "asynchronous": false,
       "locality": null,
       "lastModified": null,
-      "serviceType": "cloud",
+      "serviceType": {
+        "string": "cloud"
+      },
       "optionalAttributes": {}
     }
   },
   "publishing": {
-    "org.cedar.schemas.avro.psi.Publishing": {
-      "isPrivate": false,
-      "until": null
-    }
+    "isPrivate": false,
+    "until": null
   },
   "relationships": [
     {
       "org.cedar.schemas.avro.psi.Relationship": {
-        "type": {
-          "org.cedar.schemas.avro.psi.RelationshipType": "COLLECTION"
+        "type":  {
+          "org.cedar.schemas.avro.psi.Relationship.RelationshipType": "COLLECTION"
         },
         "id": "cb03311a-0ee0-4649-92d9-f8c3a28bcb29"
       }

--- a/api-metadata/src/test/resources/parsed-record-no-discovery-or-analysis.json
+++ b/api-metadata/src/test/resources/parsed-record-no-discovery-or-analysis.json
@@ -1,0 +1,49 @@
+{
+  "type": {
+    "org.cedar.schemas.avro.psi.RecordType": "granule"
+  },
+  "discovery": null,
+  "analysis": null,
+  "fileInformation": {
+    "org.cedar.schemas.avro.psi.FileInformation": {
+      "name": "testGranuleFile.nc",
+      "size": null,
+      "checksums": [],
+      "format": "NetCDF",
+      "headers": null,
+      "optionalAttributes": {}
+    }
+  },
+  "fileLocations": {
+    "https://granule-cloud-location.cloud/abc123": {
+      "uri": "https://granule-cloud-location.cloud/abc123",
+      "type": {
+        "org.cedar.schemas.avro.psi.FileLocationType": "ACCESS"
+      },
+      "deleted": false,
+      "restricted": false,
+      "asynchronous": false,
+      "locality": null,
+      "lastModified": null,
+      "serviceType": "cloud",
+      "optionalAttributes": {}
+    }
+  },
+  "publishing": {
+    "org.cedar.schemas.avro.psi.Publishing": {
+      "isPrivate": false,
+      "until": null
+    }
+  },
+  "relationships": [
+    {
+      "org.cedar.schemas.avro.psi.Relationship": {
+        "type": {
+          "org.cedar.schemas.avro.psi.RelationshipType": "COLLECTION"
+        },
+        "id": "cb03311a-0ee0-4649-92d9-f8c3a28bcb29"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/api-metadata/src/test/resources/parsed-record-with-default-discovery.json
+++ b/api-metadata/src/test/resources/parsed-record-with-default-discovery.json
@@ -99,7 +99,9 @@
           "parentIdentifierExists": {
             "boolean": true
           },
-          "parentIdentifierString": "cb03311a-0ee0-4649-92d9-f8c3a28bcb29",
+          "parentIdentifierString": {
+            "string": "cb03311a-0ee0-4649-92d9-f8c3a28bcb29"
+          },
           "hierarchyLevelNameExists": {
             "boolean": true
           },

--- a/api-metadata/src/test/resources/parsed-record-with-default-discovery.json
+++ b/api-metadata/src/test/resources/parsed-record-with-default-discovery.json
@@ -1,0 +1,236 @@
+{
+  "type": {
+    "org.cedar.schemas.avro.psi.RecordType": "granule"
+  },
+  "discovery": {
+    "org.cedar.schemas.avro.psi.Discovery": {
+      "fileIdentifier": {
+        "string": "testGranuleFile.nc"
+      },
+      "parentIdentifier": {
+        "string": "cb03311a-0ee0-4649-92d9-f8c3a28bcb29"
+      },
+      "hierarchyLevelName": {
+        "string": "granule"
+      },
+      "doi": null,
+      "purpose": null,
+      "status": null,
+      "credit": null,
+      "title": {
+        "string": "testGranuleFile.nc"
+      },
+      "alternateTitle": null,
+      "description": null,
+      "keywords": [],
+      "topicCategories": [],
+      "temporalBounding": null,
+      "spatialBounding": null,
+      "isGlobal": null,
+      "acquisitionInstruments": [],
+      "acquisitionOperations": [],
+      "acquisitionPlatforms": [],
+      "dataFormats": [
+        {
+          "name": {
+            "string": "NetCDF"
+          },
+          "version": null
+        }
+      ],
+      "links": [
+        {
+          "linkName": null,
+          "linkProtocol": {
+            "string": "cloud"
+          },
+          "linkUrl": {
+            "string": "https://granule-cloud-location.cloud/abc123"
+          },
+          "linkDescription": null,
+          "linkFunction": {
+            "string": "download"
+          }
+        }
+      ],
+      "responsibleParties": [],
+      "thumbnail": null,
+      "thumbnailDescription": null,
+      "creationDate": null,
+      "revisionDate": null,
+      "publicationDate": null,
+      "citeAsStatements": [],
+      "crossReferences": [],
+      "largerWorks": [],
+      "useLimitation": null,
+      "legalConstraints": [],
+      "accessFeeStatement": null,
+      "orderingInstructions": null,
+      "edition": null,
+      "dsmmAccessibility": 0,
+      "dsmmDataIntegrity": 0,
+      "dsmmDataQualityAssessment": 0,
+      "dsmmDataQualityAssurance": 0,
+      "dsmmDataQualityControlMonitoring": 0,
+      "dsmmPreservability": 0,
+      "dsmmProductionSustainability": 0,
+      "dsmmTransparencyTraceability": 0,
+      "dsmmUsability": 0,
+      "dsmmAverage": 0.0,
+      "updateFrequency": null,
+      "presentationForm": null,
+      "services": []
+    }
+  },
+  "analysis": {
+    "org.cedar.schemas.avro.psi.Analysis": {
+      "identification": {
+        "org.cedar.schemas.avro.psi.IdentificationAnalysis": {
+          "fileIdentifierExists": {
+            "boolean": true
+          },
+          "fileIdentifierString": {
+            "string": "testGranuleFile.nc"
+          },
+          "doiExists": {
+            "boolean": false
+          },
+          "doiString": null,
+          "parentIdentifierExists": {
+            "boolean": true
+          },
+          "parentIdentifierString": "cb03311a-0ee0-4649-92d9-f8c3a28bcb29",
+          "hierarchyLevelNameExists": {
+            "boolean": true
+          },
+          "matchesIdentifiers": {
+            "boolean": true
+          }
+        }
+      },
+      "titles": {
+        "org.cedar.schemas.avro.psi.TitleAnalysis": {
+          "titleExists": {
+            "boolean": true
+          },
+          "titleCharacters": {
+            "int": 18
+          },
+          "alternateTitleExists": {
+            "boolean": false
+          },
+          "alternateTitleCharacters": {
+            "int": 0
+          },
+          "titleFleschReadingEaseScore": {
+            "double": -301.78
+          },
+          "titleFleschKincaidReadingGradeLevel": {
+            "double": 55.60
+          },
+          "alternateTitleFleschReadingEaseScore": null,
+          "alternateTitleFleschKincaidReadingGradeLevel": null
+        }
+      },
+      "description": {
+        "org.cedar.schemas.avro.psi.DescriptionAnalysis": {
+          "descriptionExists": {
+            "boolean": false
+          },
+          "descriptionCharacters": {
+            "int": 0
+          },
+          "descriptionFleschReadingEaseScore": null,
+          "descriptionFleschKincaidReadingGradeLevel": null
+        }
+      },
+      "dataAccess": {
+        "org.cedar.schemas.avro.psi.DataAccessAnalysis": {
+          "dataAccessExists": {
+            "boolean": true
+          }
+        }
+      },
+      "thumbnail": {
+        "org.cedar.schemas.avro.psi.ThumbnailAnalysis": {
+          "thumbnailExists": {
+            "boolean": false
+          }
+        }
+      },
+      "temporalBounding": {
+        "org.cedar.schemas.avro.psi.TemporalBoundingAnalysis": {
+          "beginDescriptor": null,
+          "beginPrecision": null,
+          "beginIndexable": null,
+          "beginZoneSpecified": null,
+          "beginUtcDateTimeString": null,
+          "endDescriptor": null,
+          "endPrecision": null,
+          "endIndexable": null,
+          "endZoneSpecified": null,
+          "endUtcDateTimeString": null,
+          "instantDescriptor": null,
+          "instantPrecision": null,
+          "instantIndexable": null,
+          "instantZoneSpecified": null,
+          "instantUtcDateTimeString": null,
+          "rangeDescriptor": null
+        }
+      },
+      "spatialBounding": {
+        "org.cedar.schemas.avro.psi.SpatialBoundingAnalysis": {
+          "spatialBoundingExists": {
+            "boolean": false
+          },
+          "isValid": {
+            "boolean": false
+          },
+          "validationError": {
+            "string": "Missing geographic bounding box"
+          }
+        }
+      }
+    }
+  },
+  "fileInformation": {
+    "org.cedar.schemas.avro.psi.FileInformation": {
+      "name": "testGranuleFile.nc",
+      "size": 108162440,
+      "checksums": [],
+      "format": {
+        "string": "NetCDF"
+      },
+      "headers": null,
+      "optionalAttributes": {}
+    }
+  },
+  "fileLocations": {
+    "https://granule-cloud-location.cloud/abc123": {
+      "uri": "https://granule-cloud-location.cloud/abc123",
+      "type": {
+        "org.cedar.schemas.avro.psi.FileLocationType": "ACCESS"
+      },
+      "deleted": false,
+      "restricted": false,
+      "asynchronous": false,
+      "locality": null,
+      "lastModified": null,
+      "serviceType": {
+        "string": "cloud"
+      },
+      "optionalAttributes": {}
+    }
+  },
+  "publishing": {
+    "isPrivate": false,
+    "until": null
+  },
+  "relationships": [
+    {
+      "type": "COLLECTION",
+      "id": "cb03311a-0ee0-4649-92d9-f8c3a28bcb29"
+    }
+  ],
+  "errors": []
+}

--- a/api-metadata/src/test/resources/parsed-record-with-default-discovery.json
+++ b/api-metadata/src/test/resources/parsed-record-with-default-discovery.json
@@ -230,7 +230,9 @@
   },
   "relationships": [
     {
-      "type": "COLLECTION",
+      "type": {
+        "org.cedar.schemas.avro.psi.RelationshipType": "COLLECTION"
+      },
       "id": "cb03311a-0ee0-4649-92d9-f8c3a28bcb29"
     }
   ],

--- a/api-metadata/src/test/resources/test-iso-collection-type-1.xml
+++ b/api-metadata/src/test/resources/test-iso-collection-type-1.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<gmi:MI_Metadata xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gmi="http://www.isotc211.org/2005/gmi" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.isotc211.org/2005/gmi">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>gov.super.important:FILE-ID</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:hierarchyLevelName>
+    <gco:CharacterString>collection</gco:CharacterString>
+  </gmd:hierarchyLevelName>
+</gmi:MI_Metadata>

--- a/api-metadata/src/test/resources/test-iso-collection-type-2.xml
+++ b/api-metadata/src/test/resources/test-iso-collection-type-2.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<gmi:MI_Metadata xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gmi="http://www.isotc211.org/2005/gmi" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.isotc211.org/2005/gmi">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>gov.super.important:FILE-ID</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:parentIdentifier>
+    <gco:CharacterString>gov.super.important:PARENT-ID</gco:CharacterString>
+  </gmd:parentIdentifier>
+</gmi:MI_Metadata>

--- a/api-metadata/src/test/resources/test-iso-error-type.xml
+++ b/api-metadata/src/test/resources/test-iso-error-type.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<gmi:MI_Metadata xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gmi="http://www.isotc211.org/2005/gmi" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.isotc211.org/2005/gmi">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>gov.super.important:FILE-ID</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:hierarchyLevelName>
+    <gco:CharacterString>GRANULE</gco:CharacterString>
+  </gmd:hierarchyLevelName>
+</gmi:MI_Metadata>

--- a/api-metadata/src/test/resources/test-iso-granule-type.xml
+++ b/api-metadata/src/test/resources/test-iso-granule-type.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<gmi:MI_Metadata xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gmi="http://www.isotc211.org/2005/gmi" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.isotc211.org/2005/gmi">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>gov.super.important:FILE-ID</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:parentIdentifier>
+    <gco:CharacterString>gov.super.important:PARENT-ID</gco:CharacterString>
+  </gmd:parentIdentifier>
+  <gmd:hierarchyLevelName>
+    <gco:CharacterString>Granule</gco:CharacterString>
+  </gmd:hierarchyLevelName>
+</gmi:MI_Metadata>

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ apply plugin: 'groovy'
 subprojects {
 
   project.ext {
+    schemasVersion = '0.4.0'
     esVersion = '6.8.2'
     spockVersion = '1.2-groovy-2.5'
     testContainersVersion = '1.10.7'

--- a/docs/design/iso-indexing-mapping.md
+++ b/docs/design/iso-indexing-mapping.md
@@ -87,6 +87,7 @@ Either path is ingested, in this order:
 ***
 
 ### `hierarchyLevelName`
+This field must be present and have a value of "granule" (not case sensitive) in order for a record to be identified as such. Otherwise, it will be identified as a collection record.
 > /gmi:MI_Metadata/gmd:hierarchyLevelName/gco:CharacterString[1]
 
 ***

--- a/elastic-common/src/main/resources/mappings/ES5/search_collectionIndex.json
+++ b/elastic-common/src/main/resources/mappings/ES5/search_collectionIndex.json
@@ -16,6 +16,9 @@
         "doi": {
           "type": "keyword"
         },
+        "parentIdentifier": {
+          "type": "keyword"
+        },
         "title": {
           "type": "text"
         },

--- a/elastic-common/src/main/resources/mappings/ES6/search_collectionIndex.json
+++ b/elastic-common/src/main/resources/mappings/ES6/search_collectionIndex.json
@@ -13,6 +13,9 @@
         "doi": {
           "type": "keyword"
         },
+        "parentIdentifier": {
+          "type": "keyword"
+        },
         "title": {
           "type": "text"
         },

--- a/elastic-common/src/main/resources/pipelines/collection_pipelineDefinition.json
+++ b/elastic-common/src/main/resources/pipelines/collection_pipelineDefinition.json
@@ -350,11 +350,6 @@
       }
     },
     {
-      "remove": {
-        "field": "parentIdentifier"
-      }
-    },
-    {
       "rename": {
         "field": "keywordValues",
         "target_field": "keywords",

--- a/elastic-common/src/main/resources/pipelines/collection_pipeline_ES5-6_Definition.json
+++ b/elastic-common/src/main/resources/pipelines/collection_pipeline_ES5-6_Definition.json
@@ -227,8 +227,7 @@
           "dsmmUsability",
           "updateFrequency",
           "presentationForm",
-          "services",
-          "parentIdentifier"
+          "services"
         ],
         "ignore_missing": true
       }

--- a/helm/kibana/templates/deployment.yaml
+++ b/helm/kibana/templates/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       restartPolicy: Always
       containers:
       - name: kibana
-        image: docker.elastic.co/kibana/kibana:5.5.3
+        image: {{ printf "%s:%s" .Values.image.repository .Values.image.tag | quote }}
         env:
         - name: CLUSTER_NAME
           value: elasticsearch # default; should be variable value in prod version

--- a/helm/kibana/values.yaml
+++ b/helm/kibana/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: docker.elastic.co/kibana/kibana
-  tag: 5.5.3
+  tag: 6.8.2
   pullPolicy: IfNotPresent
 
 service:

--- a/helm/onestop-dev/values.yaml
+++ b/helm/onestop-dev/values.yaml
@@ -4,7 +4,7 @@
 # KIBANA
 ###############################################################################
 kibana:
-  enabled: false
+  enabled: true
   service:
     type: NodePort
     nodePort: 32001

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -46,9 +46,11 @@ deploy:
         # all features default to "false" in base chart, unless otherwise overridden
         features.icam: false
         features.manual-upload: false
-        features.kafka-ingest: false
+        features.kafka-ingest: true
         features.sitemap: true
         # env.ELASTICSEARCH_HOST: onestop-dev-elasticsearch
+        env.SCHEMA_REGISTRY_URL: http://psi-dev-cp-schema-registry:8081
+        env.KAFKA_BOOTSTRAP_SERVERS: PLAINTEXT://psi-dev-cp-kafka:9092
         config: |-
           ---
           logging.level.org.cedar.onestop.api.metadata: DEBUG


### PR DESCRIPTION
### Summary
OneStop now supports ParsedRecords that do not have Discovery (e.g., granules ingested via Kafka that were not XML files). The DefaultParser from cedardevs/schemas#16 is now used to extract minimally viable information from a ParsedRecord that has FileInformation, at least one FileLocation, and a COLLECTION Relationship. Afterward, an Analysis object is then added to the updated ParsedRecord. Furthermore, validation steps have been cleaned up somewhat to minimize redundant errors (but there is still some improvement to do for a future task -- see #989 for more info). Lastly, the preferred way of determining if a record is a granule has changed per #731. This last bit now means a collection may have a non-null `parentIdentifier`, and granules **_must_** have a `hierarchyLevelName` value equal to 'granule' (not case sensitive).

Resolves #972
Resolves #731 

### Warning
 **This PR depends on the cedardevs/schemas#17 PR in order to enable LoadKafkaMsgServiceTest tests to fully pass. Once that PR is merged to master and a new tag is created for the schemas repo, all OS build.gradle files with any schemas repo dependency need to be updated to the new tag. Do not merge this PR until all of the above has been completed!**