### PR TITLE
Experiment with build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ restoreCache: &restoreCache
   # Download and cache dependencies
   restore_cache:
     keys:
-    - onestop-cache-v12-{{ checksum "build.gradle" }}
+    - onestop-cache-v12-{{ checksum "build.gradle" }}-{{ checksum "admin/build.gradle" }}-{{ checksum "client/build.gradle" }}-{{ checksum "client/package.json" }}-{{ checksum "search.gradle" }}
     # fallback to using the latest cache if no exact match is found
     - onestop-cache-v12-
 
@@ -54,7 +54,7 @@ saveCache: &saveCache
     - client/build
     - client/node_modules
     - search/build
-    key: onestop-cache-v12-{{ checksum "build.gradle" }}
+    key: - onestop-cache-v12-{{ checksum "build.gradle" }}-{{ checksum "admin/build.gradle" }}-{{ checksum "client/build.gradle" }}-{{ checksum "client/package.json" }}-{{ checksum "search.gradle" }}
 
 attachWorkspace: &attachWorkspace
   - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,11 +95,32 @@ jobs:
         name: Integration Tests
         command: ./gradlew admin:integrationTest
 
+    - run:
+        name: Test Reports
+        command: ./gradlew jacocoTestReport -x test
+
+    - run:
+        name: Save test results
+        command: |
+          mkdir -p ~/tests/junit/
+          find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/tests/junit/ \;
+          find . -type f -regex ".*/build/integration-test-results/.*xml" -exec cp {} ~/tests/junit/ \;
+          find . -type f -regex ".*/build/coverage/junit/.*xml" -exec cp {} ~/tests/junit/ \;
+        when: always
+
+    - run:
+        name: Save coverage results
+        command: |
+          mkdir -p ~/tests/coverage/
+          find . -type d -regex ".*/build/reports/jacoco/" -exec cp -r {} ~/tests/coverage/ \;
+          find . -type d -regex ".*/build/coverage/lcov-report/" -exec cp -r {} ~/tests/coverage/ \;
+        when: always
+
     - deploy:
-        name: Build/Publish Admin API Image(s)
+        name: Publish Image(s)
         command: |
           echo "${CIRCLE_BRANCH}"
-          if [[ "${CIRCLE_BRANCH}" == "master" ]] || [[ "${CIRCLE_BRANCH}" == experiment* ]]; then
+          if [[ "${CIRCLE_BRANCH}" == "master" ]] || [[ "${CIRCLE_BRANCH}" == release* ]]; then
             echo ./gradlew search:jib
           else
             echo "Skipping publishing"
@@ -129,8 +150,29 @@ jobs:
         name: Integration Tests
         command: ./gradlew search:integrationTest
 
+    - run:
+        name: Test Reports
+        command: ./gradlew jacocoTestReport -x test
+
+    - run:
+        name: Save test results
+        command: |
+          mkdir -p ~/tests/junit/
+          find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/tests/junit/ \;
+          find . -type f -regex ".*/build/integration-test-results/.*xml" -exec cp {} ~/tests/junit/ \;
+          find . -type f -regex ".*/build/coverage/junit/.*xml" -exec cp {} ~/tests/junit/ \;
+        when: always
+
+    - run:
+        name: Save coverage results
+        command: |
+          mkdir -p ~/tests/coverage/
+          find . -type d -regex ".*/build/reports/jacoco/" -exec cp -r {} ~/tests/coverage/ \;
+          find . -type d -regex ".*/build/coverage/lcov-report/" -exec cp -r {} ~/tests/coverage/ \;
+        when: always
+
     - deploy:
-        name: Build/Publish Search API Image(s)
+        name: Publish Image(s)
         command: |
           echo "${CIRCLE_BRANCH}"
           if [[ "${CIRCLE_BRANCH}" == "master" ]] || [[ "${CIRCLE_BRANCH}" == release* ]]; then
@@ -144,63 +186,69 @@ jobs:
         paths:
         - search/build
 
-  client-build:
+  client:
     <<: *defaults
     steps:
-      - <<: *attachWorkspace
+    - <<: *attachWorkspace
 
-      - run:
-          name: Build Client
-          command: ./gradlew client:assemble
+    - run:
+        name: Assemble, Check
+        command: ./gradlew --parallel client:assemble client:check
 
-      - persist_to_workspace:
-          root: ~/repo
-          paths:
-            - .gradle
-            - client/build
-            - client/node_modules
-            - elastic-common/build
+    - deploy:
+        name: Publish Image(s)
+        command: |
+          echo "${CIRCLE_BRANCH}"
+          if [[ "${CIRCLE_BRANCH}" == "master" ]] || [[ "${CIRCLE_BRANCH}" == experiment* ]]; then
+            echo ./gradlew client:jib
+          else
+            echo "Skipping publishing"
+          fi
 
-
-
-
-
-  client-test:
+    - persist_to_workspace:
+        root: ~/repo
+        paths:
+          - client/build
+          - client/node_modules
+          -
+  finalize:
     <<: *defaults
+
     steps:
-      - <<: *attachWorkspace
+    - <<: *attachWorkspace
 
-      - run:
-          name: Client Unit Tests
-          command: ./gradlew client:test
+    - run:
+        name: Post coverage results to codecov
+        command: |
+          bash <(curl -s https://codecov.io/bash)
 
-      - persist_to_workspace:
-          root: ~/repo
-          paths:
-#            - .gradle
-            - client/build
+    - <<: *saveCache
 
-  admin-integration-test:
-    <<: *defaultsWithElasticsearch
-    <<: *env
+  check-owasp-cve:
+    <<: *defaults
+
     steps:
-      - <<: *attachWorkspace
+    - <<: *attachWorkspace
 
-      - run:
-          name: Wait for Elasticsearch
-          command: dockerize -wait tcp://localhost:9200 -timeout 1m
+    - run:
+        name: Run OWASP Check
+        command: ./gradlew dependencyCheckAnalyze
+        no_output_timeout: 30m
 
-      - run:
-          name: Admin API Integration Tests
-          command: ./gradlew admin:integrationTest
+    - run:
+        name: Save coverage results
+        command: |
+          mkdir -p ~/owasp/admin/
+          find . -type d -regex "admin/build/reports/dependency-check-report.html" -exec cp -r {} ~/tests/admin/ \;
+          mkdir -p ~/owasp/search/
+          find . -type d -regex "search/build/reports/dependency-check-report.html" -exec cp -r {} ~/tests/search/ \;
+        when: always
 
-      - persist_to_workspace:
-          root: ~/repo
-          paths:
-#            - .gradle
-            - admin/build
+    - store_test_results:
+        path: ~/owasp
 
-
+    - store_artifacts:
+        path: ~/owasp
 
   e2e:
     <<: *defaultsMachine
@@ -246,108 +294,6 @@ jobs:
             - .gradle
             - e2e-tests/build
 
-  admin-publish:
-    <<: *defaults
-
-    steps:
-      - <<: *attachWorkspace
-
-      - deploy:
-          name: Build/Publish Admin Image(s)
-          command: ./gradlew admin:jib
-
-
-
-  client-publish:
-    <<: *defaults
-
-    steps:
-      - <<: *attachWorkspace
-
-      - deploy:
-          name: Build/Publish Client Image(s)
-          command: ./gradlew client:jib
-
-  client-checks:
-    <<: *defaults
-
-    steps:
-      - <<: *attachWorkspace
-
-      - run:
-          name: Client Check Formatting
-          command: ./gradlew client:formatCheck
-
-      - run:
-          name: Client RetireJS
-          command: ./gradlew client:retire
-
-  finalize:
-    <<: *defaults
-
-    steps:
-      - <<: *attachWorkspace
-
-      - run:
-          name: Test Reports
-          command: ./gradlew jacocoTestReport -x test
-
-      - run:
-          name: Save test results
-          command: |
-            mkdir -p ~/tests/junit/
-            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/tests/junit/ \;
-            find . -type f -regex ".*/build/integration-test-results/.*xml" -exec cp {} ~/tests/junit/ \;
-            find . -type f -regex ".*/build/coverage/junit/.*xml" -exec cp {} ~/tests/junit/ \;
-          when: always
-
-      - run:
-          name: Save coverage results
-          command: |
-            mkdir -p ~/tests/coverage/
-            find . -type d -regex ".*/build/reports/jacoco/" -exec cp -r {} ~/tests/coverage/ \;
-            find . -type d -regex ".*/build/coverage/lcov-report/" -exec cp -r {} ~/tests/coverage/ \;
-          when: always
-
-      - run:
-          name: Post coverage results to codecov
-          command: |
-            bash <(curl -s https://codecov.io/bash)
-
-      - store_test_results:
-          path: ~/tests
-
-      - store_artifacts:
-          path: ~/tests
-
-      - <<: *saveCache
-
-  check-owasp-cve:
-    <<: *defaults
-
-    steps:
-      - <<: *attachWorkspace
-
-      - run:
-          name: Run OWASP Check
-          command: ./gradlew dependencyCheckAnalyze
-          no_output_timeout: 30m
-
-      - run:
-          name: Save coverage results
-          command: |
-            mkdir -p ~/owasp/admin/
-            find . -type d -regex "admin/build/reports/dependency-check-report.html" -exec cp -r {} ~/tests/admin/ \;
-            mkdir -p ~/owasp/search/
-            find . -type d -regex "search/build/reports/dependency-check-report.html" -exec cp -r {} ~/tests/search/ \;
-          when: always
-
-      - store_test_results:
-          path: ~/owasp
-
-      - store_artifacts:
-          path: ~/owasp
-
 workflows:
   version: 2
   build:
@@ -356,14 +302,16 @@ workflows:
     - admin:
         requires:
         - checkout
+    - client:
+        requires:
+        - checkout
     - search:
         requires:
         - checkout
-
     - finalize:
         requires:
         - admin
-#        - client
+        - client
         - search
 
   nightly:
@@ -376,20 +324,9 @@ workflows:
                 - master
     jobs:
       - checkout
-      - client-build:
-          requires:
-            - checkout
-      - meta-build:
-          requires:
-            - checkout
-      - search-build:
-          requires:
-            - checkout
       - check-owasp-cve:
           requires:
             - checkout
       - e2e:
           requires:
-            - client-build
-            - meta-build
-            - search-build
+            - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,11 +68,9 @@ jobs:
           name: Setup Gradle
           command: ./gradlew help
       - persist_to_workspace:
-          root: ~
+          root: ~/repo
           paths:
             - .
-            - .gradle
-            - repo
 
   search-build:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,22 +76,39 @@ jobs:
           paths:
             - .
 
-  search-build:
-    <<: *defaults
+  search:
+    <<: *defaultsWithElasticsearch
+    <<: *env
 
     steps:
-      - <<: *attachWorkspace
+    - <<: *attachWorkspace
 
-      - run:
-          name: Build Search API
-          command: ./gradlew search:assemble
+    - run:
+        name: Assemble, Check, Test
+        command: ./gradlew --parallel search:assemble search:check search:test
 
-      - persist_to_workspace:
-          root: ~/repo
-          paths:
-            - .gradle
-            - search/build
-            - elastic-common/build
+    - run:
+        name: Wait for Elasticsearch
+        command: dockerize -wait tcp://localhost:9200 -timeout 1m
+
+    - run:
+        name: Search Integration Tests
+        command: ./gradlew search:integrationTest
+
+    - deploy:
+        name: Build/Publish Search API Image(s)
+        command: |
+          echo "${CIRCLE_BRANCH}"
+          if [[ "${CIRCLE_BRANCH}" == "master" ]] || [[ "${CIRCLE_BRANCH}" == release* ]]; then
+            echo ./gradlew search:jib
+          else
+            echo "Skipping publishing"
+          fi
+
+    - persist_to_workspace:
+        root: ~/repo
+        paths:
+        - search/build
 
   client-build:
     <<: *defaults
@@ -141,24 +158,7 @@ jobs:
             - .gradle
             - admin/build
 
-  search-test:
-    <<: *defaults
-    steps:
-      - <<: *attachWorkspace
 
-      - run:
-          name: Generate Dummy Keystore
-          command: ./gradlew jks
-
-      - run:
-          name: Search API Unit Tests
-          command: ./gradlew search:test
-
-      - persist_to_workspace:
-          root: ~/repo
-          paths:
-            - .gradle
-            - search/build
 
   client-test:
     <<: *defaults
@@ -195,25 +195,7 @@ jobs:
 #            - .gradle
             - admin/build
 
-  search-integration-test:
-    <<: *defaultsWithElasticsearch
-    <<: *env
-    steps:
-      - <<: *attachWorkspace
 
-      - run:
-          name: Wait for Elasticsearch
-          command: dockerize -wait tcp://localhost:9200 -timeout 1m
-
-      - run:
-          name: Search Integration Tests
-          command: ./gradlew search:integrationTest
-
-      - persist_to_workspace:
-          root: ~/repo
-          paths:
-#            - .gradle
-            - search/build
 
   e2e:
     <<: *defaultsMachine
@@ -269,15 +251,7 @@ jobs:
           name: Build/Publish Admin Image(s)
           command: ./gradlew admin:jib
 
-  search-publish:
-    <<: *defaults
 
-    steps:
-      - <<: *attachWorkspace
-
-      - deploy:
-          name: Build/Publish Search API Image(s)
-          command: ./gradlew search:jib
 
   client-publish:
     <<: *defaults
@@ -303,7 +277,7 @@ jobs:
           name: Client RetireJS
           command: ./gradlew client:retire
 
-  report-tests:
+  finalize:
     <<: *defaults
 
     steps:
@@ -341,6 +315,8 @@ jobs:
       - store_artifacts:
           path: ~/tests
 
+      - <<: *saveCache
+
   check-owasp-cve:
     <<: *defaults
 
@@ -372,57 +348,45 @@ workflows:
   build:
     jobs:
       - checkout
-      - admin-build:
+      - search:
           requires:
-            - checkout
-      - admin-test:
-          requires:
-            - admin-build
-      - admin-integration-test:
-          requires:
-            - admin-test
-      - admin-publish:
-          filters:  # using regex filters requires the entire branch to match
-            branches:
-              only:  # only branches matching the below regex filters will run
-                - master
-                - /release.*/
-          requires:
-            - admin-integration-test
-      - search-build:
-          requires:
-            - checkout
-      - search-test:
-          requires:
-            - search-build
-      - search-integration-test:
-          requires:
-            - search-test
-      - search-publish:
-          filters:  # using regex filters requires the entire branch to match
-            branches:
-              only:  # only branches matching the below regex filters will run
-                - master
-                - /release.*/
-          requires:
-            - search-integration-test
-      - client-build:
-          requires:
-            - checkout
-      - client-test:
-          requires:
-            - client-build
-      - client-publish:
-          filters:  # using regex filters requires the entire branch to match
-            branches:
-              only:  # only branches matching the below regex filters will run
-                - master
-                - /release.*/
-          requires:
-            - client-test
-      - client-checks:
-          requires:
-            - client-build
+          - checkout
+#      - admin-build:
+#          requires:
+#            - checkout
+#      - admin-test:
+#          requires:
+#            - admin-build
+#      - admin-integration-test:
+#          requires:
+#            - admin-test
+#      - admin-publish:
+#          filters:  # using regex filters requires the entire branch to match
+#            branches:
+#              only:  # only branches matching the below regex filters will run
+#                - master
+#                - /release.*/
+#          requires:
+#            - admin-integration-test
+#
+#
+#      - client-build:
+#          requires:
+#            - checkout
+#      - client-test:
+#          requires:
+#            - client-build
+#      - client-publish:
+#          filters:  # using regex filters requires the entire branch to match
+#            branches:
+#              only:  # only branches matching the below regex filters will run
+#                - master
+#                - /release.*/
+#          requires:
+#            - client-test
+#      - client-checks:
+#          requires:
+#            - client-build
 
 #      - e2e:
 #          requires:
@@ -430,12 +394,11 @@ workflows:
 #            - search-integration-test
 #            - admin-integration-test
 
-      - report-tests:
+      - finalize:
           requires:
-#            - e2e
-            - client-test
-            - search-integration-test
-            - admin-integration-test
+#            - admin
+#            - client
+            - search
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,7 @@ jobs:
           paths:
             - .gradle
             - search/build
+            - elastic-common/build
 
   client-build:
     <<: *defaults
@@ -107,6 +108,7 @@ jobs:
             - .gradle
             - client/build
             - client/node_modules
+            - elastic-common/build
 
   admin-build:
     <<: *defaults
@@ -122,6 +124,7 @@ jobs:
           paths:
             - .gradle
             - admin/build
+            - elastic-common/build
 
   admin-test:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,8 +116,7 @@ jobs:
       - persist_to_workspace:
           root: ~/repo
           paths:
-            - .gradle
-            - admin/build
+            - .
 
   admin-test:
     <<: *defaults
@@ -131,10 +130,7 @@ jobs:
       - persist_to_workspace:
           root: ~/repo
           paths:
-            - .gradle
-            - admin/build/jacoco/test.exec
-            - admin/build/test-results/test
-            - admin/build/reports/test
+            - .
 
   search-test:
     <<: *defaults
@@ -188,10 +184,7 @@ jobs:
       - persist_to_workspace:
           root: ~/repo
           paths:
-            - .gradle
-            - admin/build/jacoco/integrationTest.exec
-            - admin/build/test-results/integrationTest
-            - admin/build/reports/integrationTest
+            - .
 
   search-integration-test:
     <<: *defaultsWithElasticsearch
@@ -380,7 +373,7 @@ workflows:
             - admin-build
       - admin-integration-test:
           requires:
-            - admin-build
+            - admin-test
       - admin-publish:
           filters:  # using regex filters requires the entire branch to match
             branches:
@@ -388,7 +381,7 @@ workflows:
                 - master
                 - /release.*/
           requires:
-            - admin-test
+            # - admin-test
             - admin-integration-test
       # - search-build:
       #     requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -359,36 +359,12 @@ workflows:
     - search:
         requires:
         - checkout
-#
-#      - client-build:
-#          requires:
-#            - checkout
-#      - client-test:
-#          requires:
-#            - client-build
-#      - client-publish:
-#          filters:  # using regex filters requires the entire branch to match
-#            branches:
-#              only:  # only branches matching the below regex filters will run
-#                - master
-#                - /release.*/
-#          requires:
-#            - client-test
-#      - client-checks:
-#          requires:
-#            - client-build
 
-#      - e2e:
-#          requires:
-#            - client-test
-#            - search-integration-test
-#            - admin-integration-test
-
-      - finalize:
-          requires:
-            - admin
-#            - client
-            - search
+    - finalize:
+        requires:
+        - admin
+#        - client
+        - search
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,12 +69,46 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Setup Gradle
-          command: ./gradlew help
+          name: Build shared resources
+          command: ./gradlew --parallel elastic-common:build
       - persist_to_workspace:
           root: ~/repo
           paths:
             - .
+
+  admin:
+    <<: *defaultsWithElasticsearch
+    <<: *env
+
+    steps:
+    - <<: *attachWorkspace
+
+    - run:
+        name: Assemble, Check (sans integration tests)
+        command: ./gradlew --parallel admin:assemble admin:check -x integrationTest
+
+    - run:
+        name: Wait for Elasticsearch
+        command: dockerize -wait tcp://localhost:9200 -timeout 1m
+
+    - run:
+        name: Integration Tests
+        command: ./gradlew admin:integrationTest
+
+    - deploy:
+        name: Build/Publish Admin API Image(s)
+        command: |
+          echo "${CIRCLE_BRANCH}"
+          if [[ "${CIRCLE_BRANCH}" == "master" ]] || [[ "${CIRCLE_BRANCH}" == experiment* ]]; then
+            echo ./gradlew search:jib
+          else
+            echo "Skipping publishing"
+          fi
+
+    - persist_to_workspace:
+        root: ~/repo
+        paths:
+        - admin/build
 
   search:
     <<: *defaultsWithElasticsearch
@@ -84,15 +118,15 @@ jobs:
     - <<: *attachWorkspace
 
     - run:
-        name: Assemble, Check, Test
-        command: ./gradlew --parallel search:assemble search:check search:test
+        name: Assemble, Check (sans integration tests)
+        command: ./gradlew --parallel search:assemble search:check -x integrationTest
 
     - run:
         name: Wait for Elasticsearch
         command: dockerize -wait tcp://localhost:9200 -timeout 1m
 
     - run:
-        name: Search Integration Tests
+        name: Integration Tests
         command: ./gradlew search:integrationTest
 
     - deploy:
@@ -127,36 +161,7 @@ jobs:
             - client/node_modules
             - elastic-common/build
 
-  admin-build:
-    <<: *defaults
-    steps:
-      - <<: *attachWorkspace
 
-      - run:
-          name: Build Admin API
-          command: ./gradlew admin:assemble
-
-      - persist_to_workspace:
-          root: ~/repo
-          paths:
-            - .gradle
-            - admin/build
-            - elastic-common/build
-
-  admin-test:
-    <<: *defaults
-    steps:
-      - <<: *attachWorkspace
-
-      - run:
-          name: Admin API Unit Tests
-          command: ./gradlew admin:test
-
-      - persist_to_workspace:
-          root: ~/repo
-          paths:
-            - .gradle
-            - admin/build
 
 
 
@@ -347,28 +352,13 @@ workflows:
   version: 2
   build:
     jobs:
-      - checkout
-      - search:
-          requires:
-          - checkout
-#      - admin-build:
-#          requires:
-#            - checkout
-#      - admin-test:
-#          requires:
-#            - admin-build
-#      - admin-integration-test:
-#          requires:
-#            - admin-test
-#      - admin-publish:
-#          filters:  # using regex filters requires the entire branch to match
-#            branches:
-#              only:  # only branches matching the below regex filters will run
-#                - master
-#                - /release.*/
-#          requires:
-#            - admin-integration-test
-#
+    - checkout
+    - admin:
+        requires:
+        - checkout
+    - search:
+        requires:
+        - checkout
 #
 #      - client-build:
 #          requires:
@@ -396,7 +386,7 @@ workflows:
 
       - finalize:
           requires:
-#            - admin
+            - admin
 #            - client
             - search
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ saveCache: &saveCache
     - build
     - admin/build
     - client/build
+    - client/.gradle
     - client/node_modules
     - search/build
     key: onestop-cache-v12-{{ checksum "build.gradle" }}-{{ checksum "admin/build.gradle" }}-{{ checksum "client/build.gradle" }}-{{ checksum "client/package.json" }}-{{ checksum "search/build.gradle" }}
@@ -87,9 +88,7 @@ jobs:
     - persist_to_workspace:
         root: ~/repo
         paths:
-        - .gradle_home
-        - .gradle
-        - elastic-common/build
+        - .
 
   admin:
     <<: *defaultsWithElasticsearch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -390,57 +390,57 @@ workflows:
           requires:
             - admin-test
             - admin-integration-test
-      - search-build:
-          requires:
-            - checkout
-      - search-test:
-          requires:
-            - search-build
-      - search-integration-test:
-          requires:
-            - search-build
-      - search-publish:
-          filters:  # using regex filters requires the entire branch to match
-            branches:
-              only:  # only branches matching the below regex filters will run
-                - master
-                - /release.*/
-          requires:
-            - search-test
-            - search-integration-test
-      - client-build:
-          requires:
-            - checkout
-      - client-test:
-          requires:
-            - client-build
-      - client-publish:
-          filters:  # using regex filters requires the entire branch to match
-            branches:
-              only:  # only branches matching the below regex filters will run
-                - master
-                - /release.*/
-          requires:
-            - client-test
-      - client-checks:
-          requires:
-            - client-build
-
-      - e2e:
-          requires:
-            - client-build
-            - admin-build
-            - search-build
-            - search-integration-test
-            - admin-integration-test
-
-      - report-tests:
-          requires:
-            - admin-test
-            - admin-integration-test
-            - search-test
-            - search-integration-test
-            - client-test
+      # - search-build:
+      #     requires:
+      #       - checkout
+      # - search-test:
+      #     requires:
+      #       - search-build
+      # - search-integration-test:
+      #     requires:
+      #       - search-build
+      # - search-publish:
+      #     filters:  # using regex filters requires the entire branch to match
+      #       branches:
+      #         only:  # only branches matching the below regex filters will run
+      #           - master
+      #           - /release.*/
+      #     requires:
+      #       - search-test
+      #       - search-integration-test
+      # - client-build:
+      #     requires:
+      #       - checkout
+      # - client-test:
+      #     requires:
+      #       - client-build
+      # - client-publish:
+      #     filters:  # using regex filters requires the entire branch to match
+      #       branches:
+      #         only:  # only branches matching the below regex filters will run
+      #           - master
+      #           - /release.*/
+      #     requires:
+      #       - client-test
+      # - client-checks:
+      #     requires:
+      #       - client-build
+      #
+      # - e2e:
+      #     requires:
+      #       - client-build
+      #       - admin-build
+      #       - search-build
+      #       - search-integration-test
+      #       - admin-integration-test
+      #
+      # - report-tests:
+      #     requires:
+      #       - admin-test
+      #       - admin-integration-test
+      #       - search-test
+      #       - search-integration-test
+      #       - client-test
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,16 +257,13 @@ jobs:
         no_output_timeout: 30m
 
     - run:
-        name: Save coverage results
+        name: Save OWASP results
         command: |
           mkdir -p ~/owasp/admin/
-          find . -type d -regex "admin/build/reports/dependency-check-report.html" -exec cp -r {} ~/tests/admin/ \;
+          find . -type d -regex "admin/build/reports/dependency-check-report.html" -exec cp -r {} ~/owasp/admin/ \;
           mkdir -p ~/owasp/search/
-          find . -type d -regex "search/build/reports/dependency-check-report.html" -exec cp -r {} ~/tests/search/ \;
+          find . -type d -regex "search/build/reports/dependency-check-report.html" -exec cp -r {} ~/owasp/search/ \;
         when: always
-
-    - store_test_results:
-        path: ~/owasp
 
     - store_artifacts:
         path: ~/owasp
@@ -306,14 +303,7 @@ jobs:
       - run:
           name: E2E tests
           command: ./gradlew e2e-tests:test
-
       - <<: *saveCache
-
-      - persist_to_workspace:
-          root: ~/repo
-          paths:
-            - .gradle
-            - e2e-tests/build
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,21 +40,21 @@ restoreCache: &restoreCache
   # Download and cache dependencies
   restore_cache:
     keys:
-    - onestop-cache-v12-{{ checksum "build.gradle" }}-{{ checksum "admin/build.gradle" }}-{{ checksum "client/build.gradle" }}-{{ checksum "client/package.json" }}-{{ checksum "search/build.gradle" }}
-    # fallback to using the latest cache if no exact match is found
-    - onestop-cache-v12-
+      - onestop-cache-v12-{{ checksum "build.gradle" }}-{{ checksum "admin/build.gradle" }}-{{ checksum "client/build.gradle" }}-{{ checksum "client/package.json" }}-{{ checksum "search/build.gradle" }}
+      # fallback to using the latest cache if no exact match is found
+      - onestop-cache-v12-
 
 saveCache: &saveCache
   save_cache:
     paths:
-    - .gradle_home
-    - .gradle
-    - build
-    - admin/build
-    - client/build
-    - client/.gradle
-    - client/node_modules
-    - search/build
+      - .gradle_home
+      - .gradle
+      - build
+      - admin/build
+      - client/build
+      - client/.gradle
+      - client/node_modules
+      - search/build
     key: onestop-cache-v12-{{ checksum "build.gradle" }}-{{ checksum "admin/build.gradle" }}-{{ checksum "client/build.gradle" }}-{{ checksum "client/package.json" }}-{{ checksum "search/build.gradle" }}
 
 attachWorkspace: &attachWorkspace
@@ -66,207 +66,207 @@ jobs:
   checkout:
     <<: *defaults
     steps:
-    - restore_cache:
-        keys:
-        - source-v1-{{ .Branch }}-{{ .Revision }}
-        - source-v1-{{ .Branch }}-
-        - source-v1-
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+            - source-v1-{{ .Branch }}-
+            - source-v1-
 
-    - checkout
+      - checkout
 
-    - save_cache:
-        key: source-v1-{{ .Branch }}-{{ .Revision }}
-        paths:
-        - ".git"
+      - save_cache:
+          key: source-v1-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - ".git"
 
-    - <<: *restoreCache
+      - <<: *restoreCache
 
-    - run:
-        name: Build shared resources
-        command: ./gradlew --parallel elastic-common:build
+      - run:
+          name: Build shared resources
+          command: ./gradlew --parallel elastic-common:build
 
-    - persist_to_workspace:
-        root: ~/repo
-        paths:
-        - .
+      - persist_to_workspace:
+          root: ~/repo
+          paths:
+            - .
 
   admin:
     <<: *defaultsWithElasticsearch
     <<: *env
 
     steps:
-    - <<: *attachWorkspace
+      - <<: *attachWorkspace
 
-    - run:
-        name: Assemble, Check (sans integration tests)
-        command: ./gradlew --parallel admin:assemble admin:check -x integrationTest
+      - run:
+          name: Assemble, Check (sans integration tests)
+          command: ./gradlew --parallel admin:assemble admin:check -x integrationTest
 
-    - run:
-        name: Wait for Elasticsearch
-        command: dockerize -wait tcp://localhost:9200 -timeout 1m
+      - run:
+          name: Wait for Elasticsearch
+          command: dockerize -wait tcp://localhost:9200 -timeout 1m
 
-    - run:
-        name: Integration Tests
-        command: ./gradlew admin:integrationTest
+      - run:
+          name: Integration Tests
+          command: ./gradlew admin:integrationTest
 
-    - run:
-        name: Test Reports
-        command: ./gradlew jacocoTestReport -x test
+      - run:
+          name: Test Reports
+          command: ./gradlew jacocoTestReport -x test
 
-    - run:
-        name: Save test results
-        command: |
-          mkdir -p ~/tests/junit/
-          find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/tests/junit/ \;
-          find . -type f -regex ".*/build/integration-test-results/.*xml" -exec cp {} ~/tests/junit/ \;
-          find . -type f -regex ".*/build/coverage/junit/.*xml" -exec cp {} ~/tests/junit/ \;
-        when: always
+      - run:
+          name: Save test results
+          command: |
+            mkdir -p ~/tests/junit/
+            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/tests/junit/ \;
+            find . -type f -regex ".*/build/integration-test-results/.*xml" -exec cp {} ~/tests/junit/ \;
+            find . -type f -regex ".*/build/coverage/junit/.*xml" -exec cp {} ~/tests/junit/ \;
+          when: always
 
-    - store_test_results:
-        path: ~/tests
+      - store_test_results:
+          path: ~/tests
 
-    - store_artifacts:
-        path: ~/tests
+      - store_artifacts:
+          path: ~/tests
 
-    - deploy:
-        name: Publish Image(s)
-        command: |
-          echo "${CIRCLE_BRANCH}"
-          if [[ "${CIRCLE_BRANCH}" == "master" ]] || [[ "${CIRCLE_BRANCH}" == release* ]]; then
-            ./gradlew search:jib
-          else
-            echo "Skipping publishing"
-          fi
+      - deploy:
+          name: Publish Image(s)
+          command: |
+            echo "${CIRCLE_BRANCH}"
+            if [[ "${CIRCLE_BRANCH}" == "master" ]] || [[ "${CIRCLE_BRANCH}" == release* ]]; then
+              ./gradlew search:jib
+            else
+              echo "Skipping publishing"
+            fi
 
-    - persist_to_workspace:
-        root: ~/repo
-        paths:
-        - admin/build
+      - persist_to_workspace:
+          root: ~/repo
+          paths:
+            - admin/build
 
   search:
     <<: *defaultsWithElasticsearch
     <<: *env
 
     steps:
-    - <<: *attachWorkspace
+      - <<: *attachWorkspace
 
-    - run:
-        name: Assemble, Check (sans integration tests)
-        command: ./gradlew --parallel search:assemble search:check -x integrationTest
+      - run:
+          name: Assemble, Check (sans integration tests)
+          command: ./gradlew --parallel search:assemble search:check -x integrationTest
 
-    - run:
-        name: Wait for Elasticsearch
-        command: dockerize -wait tcp://localhost:9200 -timeout 1m
+      - run:
+          name: Wait for Elasticsearch
+          command: dockerize -wait tcp://localhost:9200 -timeout 1m
 
-    - run:
-        name: Integration Tests
-        command: ./gradlew search:integrationTest
+      - run:
+          name: Integration Tests
+          command: ./gradlew search:integrationTest
 
-    - run:
-        name: Test Reports
-        command: ./gradlew jacocoTestReport -x test
+      - run:
+          name: Test Reports
+          command: ./gradlew jacocoTestReport -x test
 
-    - run:
-        name: Save test results
-        command: |
-          mkdir -p ~/tests/junit/
-          find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/tests/junit/ \;
-          find . -type f -regex ".*/build/integration-test-results/.*xml" -exec cp {} ~/tests/junit/ \;
-          find . -type f -regex ".*/build/coverage/junit/.*xml" -exec cp {} ~/tests/junit/ \;
-        when: always
+      - run:
+          name: Save test results
+          command: |
+            mkdir -p ~/tests/junit/
+            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/tests/junit/ \;
+            find . -type f -regex ".*/build/integration-test-results/.*xml" -exec cp {} ~/tests/junit/ \;
+            find . -type f -regex ".*/build/coverage/junit/.*xml" -exec cp {} ~/tests/junit/ \;
+          when: always
 
-    - store_test_results:
-        path: ~/tests
+      - store_test_results:
+          path: ~/tests
 
-    - store_artifacts:
-        path: ~/tests
+      - store_artifacts:
+          path: ~/tests
 
-    - deploy:
-        name: Publish Image(s)
-        command: |
-          echo "${CIRCLE_BRANCH}"
-          if [[ "${CIRCLE_BRANCH}" == "master" ]] || [[ "${CIRCLE_BRANCH}" == release* ]]; then
-            ./gradlew search:jib
-          else
-            echo "Skipping publishing"
-          fi
+      - deploy:
+          name: Publish Image(s)
+          command: |
+            echo "${CIRCLE_BRANCH}"
+            if [[ "${CIRCLE_BRANCH}" == "master" ]] || [[ "${CIRCLE_BRANCH}" == release* ]]; then
+              ./gradlew search:jib
+            else
+              echo "Skipping publishing"
+            fi
 
-    - persist_to_workspace:
-        root: ~/repo
-        paths:
-        - search/build
+      - persist_to_workspace:
+          root: ~/repo
+          paths:
+            - search/build
 
   client:
     <<: *defaults
     steps:
-    - <<: *attachWorkspace
+      - <<: *attachWorkspace
 
-    - run:
-        name: Assemble, Check
-        command: ./gradlew --parallel client:assemble client:check
+      - run:
+          name: Assemble, Check
+          command: ./gradlew --parallel client:assemble client:check
 
-    - deploy:
-        name: Publish Image(s)
-        command: |
-          echo "${CIRCLE_BRANCH}"
-          if [[ "${CIRCLE_BRANCH}" == "master" ]] || [[ "${CIRCLE_BRANCH}" == release* ]]; then
-            ./gradlew client:jib
-          else
-            echo "Skipping publishing"
-          fi
+      - deploy:
+          name: Publish Image(s)
+          command: |
+            echo "${CIRCLE_BRANCH}"
+            if [[ "${CIRCLE_BRANCH}" == "master" ]] || [[ "${CIRCLE_BRANCH}" == release* ]]; then
+              ./gradlew client:jib
+            else
+              echo "Skipping publishing"
+            fi
 
-    - persist_to_workspace:
-        root: ~/repo
-        paths:
-          - client/build
-          - client/node_modules
-          -
+      - persist_to_workspace:
+          root: ~/repo
+          paths:
+            - client/build
+            - client/node_modules
+            -
   finalize:
     <<: *defaults
 
     steps:
-    - <<: *attachWorkspace
+      - <<: *attachWorkspace
 
-    - run:
-        name: Save coverage results
-        command: |
-          mkdir -p ~/tests/coverage/
-          find . -type d -regex ".*/build/reports/jacoco/" -exec cp -r {} ~/tests/coverage/ \;
-          find . -type d -regex ".*/build/coverage/lcov-report/" -exec cp -r {} ~/tests/coverage/ \;
-        when: always
+      - run:
+          name: Save coverage results
+          command: |
+            mkdir -p ~/tests/coverage/
+            find . -type d -regex ".*/build/reports/jacoco/" -exec cp -r {} ~/tests/coverage/ \;
+            find . -type d -regex ".*/build/coverage/lcov-report/" -exec cp -r {} ~/tests/coverage/ \;
+          when: always
 
-    - store_artifacts:
-        path: ~/tests/coverage
+      - store_artifacts:
+          path: ~/tests/coverage
 
-    - run:
-        name: Post coverage results to codecov
-        command: |
-          bash <(curl -s https://codecov.io/bash)
+      - run:
+          name: Post coverage results to codecov
+          command: |
+            bash <(curl -s https://codecov.io/bash)
 
-    - <<: *saveCache
+      - <<: *saveCache
 
   check-owasp-cve:
     <<: *defaults
 
     steps:
-    - <<: *attachWorkspace
+      - <<: *attachWorkspace
 
-    - run:
-        name: Run OWASP Check
-        command: ./gradlew dependencyCheckAnalyze
-        no_output_timeout: 30m
+      - run:
+          name: Run OWASP Check
+          command: ./gradlew dependencyCheckAnalyze
+          no_output_timeout: 30m
 
-    - run:
-        name: Save OWASP results
-        command: |
-          mkdir -p ~/owasp/admin/
-          find . -type d -regex "admin/build/reports/dependency-check-report.html" -exec cp -r {} ~/owasp/admin/ \;
-          mkdir -p ~/owasp/search/
-          find . -type d -regex "search/build/reports/dependency-check-report.html" -exec cp -r {} ~/owasp/search/ \;
-        when: always
+      - run:
+          name: Save OWASP results
+          command: |
+            mkdir -p ~/owasp/admin/
+            find . -type d -regex "admin/build/reports/dependency-check-report.html" -exec cp -r {} ~/owasp/admin/ \;
+            mkdir -p ~/owasp/search/
+            find . -type d -regex "search/build/reports/dependency-check-report.html" -exec cp -r {} ~/owasp/search/ \;
+          when: always
 
-    - store_artifacts:
-        path: ~/owasp
+      - store_artifacts:
+          path: ~/owasp
 
   e2e:
     <<: *defaultsMachine
@@ -308,21 +308,21 @@ workflows:
   version: 2
   build:
     jobs:
-    - checkout
-    - admin:
-        requires:
-        - checkout
-    - client:
-        requires:
-        - checkout
-    - search:
-        requires:
-        - checkout
-    - finalize:
-        requires:
-        - admin
-        - client
-        - search
+      - checkout
+      - admin:
+          requires:
+            - checkout
+      - client:
+          requires:
+            - checkout
+      - search:
+          requires:
+            - checkout
+      - finalize:
+          requires:
+            - admin
+            - client
+            - search
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,14 +65,28 @@ jobs:
   checkout:
     <<: *defaults
     steps:
-      - <<: *restoreCache
-      - checkout
-      - run:
-          name: Build shared resources
-          command: ./gradlew --parallel elastic-common:build
-      - persist_to_workspace:
-          root: ~/repo
-          paths:
+    - restore_cache:
+        keys:
+        - source-v1-{{ .Branch }}-{{ .Revision }}
+        - source-v1-{{ .Branch }}-
+        - source-v1-
+
+    - checkout
+
+    - save_cache:
+        key: source-v1-{{ .Branch }}-{{ .Revision }}
+        paths:
+        - ".git"
+
+    - <<: *restoreCache
+
+    - run:
+        name: Build shared resources
+        command: ./gradlew --parallel elastic-common:build
+
+    - persist_to_workspace:
+        root: ~/repo
+        paths:
             - .
 
   admin:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,14 +38,14 @@ env: &env
 
 restoreCache: &restoreCache
   # Download and cache dependencies
-  restore_cache:
+  - restore_cache:
       keys:
       - onestop-cache-v12-{{ checksum "build.gradle" }}
       # fallback to using the latest cache if no exact match is found
       - onestop-cache-v12-
 
 saveCache: &saveCache
-  save_cache:
+  - save_cache:
       paths:
         - .gradle_home
         - .gradle
@@ -54,7 +54,6 @@ saveCache: &saveCache
         - client/build
         - client/node_modules
         - search/build
-
       key: onestop-cache-v12-{{ checksum "build.gradle" }}
 
 attachWorkspace: &attachWorkspace
@@ -121,7 +120,7 @@ jobs:
         command: |
           echo "${CIRCLE_BRANCH}"
           if [[ "${CIRCLE_BRANCH}" == "master" ]] || [[ "${CIRCLE_BRANCH}" == release* ]]; then
-            echo ./gradlew search:jib
+            ./gradlew search:jib
           else
             echo "Skipping publishing"
           fi
@@ -176,7 +175,7 @@ jobs:
         command: |
           echo "${CIRCLE_BRANCH}"
           if [[ "${CIRCLE_BRANCH}" == "master" ]] || [[ "${CIRCLE_BRANCH}" == release* ]]; then
-            echo ./gradlew search:jib
+            ./gradlew search:jib
           else
             echo "Skipping publishing"
           fi
@@ -199,8 +198,8 @@ jobs:
         name: Publish Image(s)
         command: |
           echo "${CIRCLE_BRANCH}"
-          if [[ "${CIRCLE_BRANCH}" == "master" ]] || [[ "${CIRCLE_BRANCH}" == experiment* ]]; then
-            echo ./gradlew client:jib
+          if [[ "${CIRCLE_BRANCH}" == "master" ]] || [[ "${CIRCLE_BRANCH}" == release* ]]; then
+            ./gradlew client:jib
           else
             echo "Skipping publishing"
           fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,13 @@
 defaults: &defaults
   docker:
     - image: circleci/openjdk:11-jdk
+  environment:
+    - GRADLE_USER_HOME: ~/repo/.gradle_home
   working_directory: ~/repo
 
 defaultsWithElasticsearch: &defaultsWithElasticsearch
+  environment:
+    - GRADLE_USER_HOME: ~/repo/.gradle_home
   docker:
     - image: circleci/openjdk:11-jdk # primary container to issue gradle commands from
     - image: docker.elastic.co/elasticsearch/elasticsearch:6.8.2
@@ -36,22 +40,22 @@ restoreCache: &restoreCache
   # Download and cache dependencies
   restore_cache:
       keys:
-      - onestop-cache-v11-{{ checksum "build.gradle" }}
+      - onestop-cache-v12-{{ checksum "build.gradle" }}
       # fallback to using the latest cache if no exact match is found
-      - onestop-cache-v11-
+      - onestop-cache-v12-
 
 saveCache: &saveCache
   save_cache:
       paths:
-        - ~/.gradle/caches/
-        - ~/.gradle/wrapper/
+        - .gradle_home
         - .gradle
-        - client/.gradle
-        - client/node_modules
-        - client/build
+        - build
         - admin/build
+        - client/build
+        - client/node_modules
         - search/build
-      key: onestop-cache-v11-{{ checksum "build.gradle" }}
+
+      key: onestop-cache-v12-{{ checksum "build.gradle" }}
 
 attachWorkspace: &attachWorkspace
   - attach_workspace:
@@ -116,7 +120,8 @@ jobs:
       - persist_to_workspace:
           root: ~/repo
           paths:
-            - .
+            - .gradle
+            - admin/build
 
   admin-test:
     <<: *defaults
@@ -130,7 +135,8 @@ jobs:
       - persist_to_workspace:
           root: ~/repo
           paths:
-            - .
+            - .gradle
+            - admin/build
 
   search-test:
     <<: *defaults
@@ -149,9 +155,7 @@ jobs:
           root: ~/repo
           paths:
             - .gradle
-            - search/build/jacoco/test.exec
-            - search/build/test-results/test
-            - search/build/reports/test
+            - search/build
 
   client-test:
     <<: *defaults
@@ -165,6 +169,7 @@ jobs:
       - persist_to_workspace:
           root: ~/repo
           paths:
+#            - .gradle
             - client/build
 
   admin-integration-test:
@@ -184,7 +189,8 @@ jobs:
       - persist_to_workspace:
           root: ~/repo
           paths:
-            - .
+#            - .gradle
+            - admin/build
 
   search-integration-test:
     <<: *defaultsWithElasticsearch
@@ -203,10 +209,8 @@ jobs:
       - persist_to_workspace:
           root: ~/repo
           paths:
-            - .gradle
-            - search/build/jacoco/integrationTest.exec
-            - search/build/test-results/integrationTest
-            - search/build/reports/integrationTest
+#            - .gradle
+            - search/build
 
   e2e:
     <<: *defaultsMachine
@@ -381,59 +385,54 @@ workflows:
                 - master
                 - /release.*/
           requires:
-            # - admin-test
             - admin-integration-test
-      # - search-build:
-      #     requires:
-      #       - checkout
-      # - search-test:
-      #     requires:
-      #       - search-build
-      # - search-integration-test:
-      #     requires:
-      #       - search-build
-      # - search-publish:
-      #     filters:  # using regex filters requires the entire branch to match
-      #       branches:
-      #         only:  # only branches matching the below regex filters will run
-      #           - master
-      #           - /release.*/
-      #     requires:
-      #       - search-test
-      #       - search-integration-test
-      # - client-build:
-      #     requires:
-      #       - checkout
-      # - client-test:
-      #     requires:
-      #       - client-build
-      # - client-publish:
-      #     filters:  # using regex filters requires the entire branch to match
-      #       branches:
-      #         only:  # only branches matching the below regex filters will run
-      #           - master
-      #           - /release.*/
-      #     requires:
-      #       - client-test
-      # - client-checks:
-      #     requires:
-      #       - client-build
-      #
-      # - e2e:
-      #     requires:
-      #       - client-build
-      #       - admin-build
-      #       - search-build
-      #       - search-integration-test
-      #       - admin-integration-test
-      #
-      # - report-tests:
-      #     requires:
-      #       - admin-test
-      #       - admin-integration-test
-      #       - search-test
-      #       - search-integration-test
-      #       - client-test
+      - search-build:
+          requires:
+            - checkout
+      - search-test:
+          requires:
+            - search-build
+      - search-integration-test:
+          requires:
+            - search-test
+      - search-publish:
+          filters:  # using regex filters requires the entire branch to match
+            branches:
+              only:  # only branches matching the below regex filters will run
+                - master
+                - /release.*/
+          requires:
+            - search-integration-test
+      - client-build:
+          requires:
+            - checkout
+      - client-test:
+          requires:
+            - client-build
+      - client-publish:
+          filters:  # using regex filters requires the entire branch to match
+            branches:
+              only:  # only branches matching the below regex filters will run
+                - master
+                - /release.*/
+          requires:
+            - client-test
+      - client-checks:
+          requires:
+            - client-build
+
+#      - e2e:
+#          requires:
+#            - client-test
+#            - search-integration-test
+#            - admin-integration-test
+
+      - report-tests:
+          requires:
+#            - e2e
+            - client-test
+            - search-integration-test
+            - admin-integration-test
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ restoreCache: &restoreCache
   # Download and cache dependencies
   restore_cache:
     keys:
-    - onestop-cache-v12-{{ checksum "build.gradle" }}-{{ checksum "admin/build.gradle" }}-{{ checksum "client/build.gradle" }}-{{ checksum "client/package.json" }}-{{ checksum "search.gradle" }}
+    - onestop-cache-v12-{{ checksum "build.gradle" }}-{{ checksum "admin/build.gradle" }}-{{ checksum "client/build.gradle" }}-{{ checksum "client/package.json" }}-{{ checksum "search/build.gradle" }}
     # fallback to using the latest cache if no exact match is found
     - onestop-cache-v12-
 
@@ -54,7 +54,7 @@ saveCache: &saveCache
     - client/build
     - client/node_modules
     - search/build
-    key: onestop-cache-v12-{{ checksum "build.gradle" }}-{{ checksum "admin/build.gradle" }}-{{ checksum "client/build.gradle" }}-{{ checksum "client/package.json" }}-{{ checksum "search.gradle" }}
+    key: onestop-cache-v12-{{ checksum "build.gradle" }}-{{ checksum "admin/build.gradle" }}-{{ checksum "client/build.gradle" }}-{{ checksum "client/package.json" }}-{{ checksum "search/build.gradle" }}
 
 attachWorkspace: &attachWorkspace
   - attach_workspace:
@@ -87,7 +87,9 @@ jobs:
     - persist_to_workspace:
         root: ~/repo
         paths:
-            - .
+        - .gradle_home
+        - .gradle
+        - elastic-common/build
 
   admin:
     <<: *defaultsWithElasticsearch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ saveCache: &saveCache
     - client/build
     - client/node_modules
     - search/build
-    key: - onestop-cache-v12-{{ checksum "build.gradle" }}-{{ checksum "admin/build.gradle" }}-{{ checksum "client/build.gradle" }}-{{ checksum "client/package.json" }}-{{ checksum "search.gradle" }}
+    key: onestop-cache-v12-{{ checksum "build.gradle" }}-{{ checksum "admin/build.gradle" }}-{{ checksum "client/build.gradle" }}-{{ checksum "client/package.json" }}-{{ checksum "search.gradle" }}
 
 attachWorkspace: &attachWorkspace
   - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,23 +38,23 @@ env: &env
 
 restoreCache: &restoreCache
   # Download and cache dependencies
-  - restore_cache:
-      keys:
-      - onestop-cache-v12-{{ checksum "build.gradle" }}
-      # fallback to using the latest cache if no exact match is found
-      - onestop-cache-v12-
+  restore_cache:
+    keys:
+    - onestop-cache-v12-{{ checksum "build.gradle" }}
+    # fallback to using the latest cache if no exact match is found
+    - onestop-cache-v12-
 
 saveCache: &saveCache
-  - save_cache:
-      paths:
-        - .gradle_home
-        - .gradle
-        - build
-        - admin/build
-        - client/build
-        - client/node_modules
-        - search/build
-      key: onestop-cache-v12-{{ checksum "build.gradle" }}
+  save_cache:
+    paths:
+    - .gradle_home
+    - .gradle
+    - build
+    - admin/build
+    - client/build
+    - client/node_modules
+    - search/build
+    key: onestop-cache-v12-{{ checksum "build.gradle" }}
 
 attachWorkspace: &attachWorkspace
   - attach_workspace:
@@ -63,9 +63,9 @@ attachWorkspace: &attachWorkspace
 version: 2
 jobs:
   checkout:
-    <<: *restoreCache
     <<: *defaults
     steps:
+      - <<: *restoreCache
       - checkout
       - run:
           name: Build shared resources

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,13 +121,11 @@ jobs:
           find . -type f -regex ".*/build/coverage/junit/.*xml" -exec cp {} ~/tests/junit/ \;
         when: always
 
-    - run:
-        name: Save coverage results
-        command: |
-          mkdir -p ~/tests/coverage/
-          find . -type d -regex ".*/build/reports/jacoco/" -exec cp -r {} ~/tests/coverage/ \;
-          find . -type d -regex ".*/build/coverage/lcov-report/" -exec cp -r {} ~/tests/coverage/ \;
-        when: always
+    - store_test_results:
+        path: ~/tests
+
+    - store_artifacts:
+        path: ~/tests
 
     - deploy:
         name: Publish Image(s)
@@ -176,13 +174,11 @@ jobs:
           find . -type f -regex ".*/build/coverage/junit/.*xml" -exec cp {} ~/tests/junit/ \;
         when: always
 
-    - run:
-        name: Save coverage results
-        command: |
-          mkdir -p ~/tests/coverage/
-          find . -type d -regex ".*/build/reports/jacoco/" -exec cp -r {} ~/tests/coverage/ \;
-          find . -type d -regex ".*/build/coverage/lcov-report/" -exec cp -r {} ~/tests/coverage/ \;
-        when: always
+    - store_test_results:
+        path: ~/tests
+
+    - store_artifacts:
+        path: ~/tests
 
     - deploy:
         name: Publish Image(s)
@@ -229,6 +225,17 @@ jobs:
 
     steps:
     - <<: *attachWorkspace
+
+    - run:
+        name: Save coverage results
+        command: |
+          mkdir -p ~/tests/coverage/
+          find . -type d -regex ".*/build/reports/jacoco/" -exec cp -r {} ~/tests/coverage/ \;
+          find . -type d -regex ".*/build/coverage/lcov-report/" -exec cp -r {} ~/tests/coverage/ \;
+        when: always
+
+    - store_artifacts:
+        path: ~/tests/coverage
 
     - run:
         name: Post coverage results to codecov

--- a/admin/src/integrationTest/groovy/org/cedar/onestop/api/admin/MigrationIntegrationTest.groovy
+++ b/admin/src/integrationTest/groovy/org/cedar/onestop/api/admin/MigrationIntegrationTest.groovy
@@ -42,7 +42,7 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
     webEnvironment = RANDOM_PORT
 )
 @Slf4j
-@TestPropertySource(properties = ['kafka.bootstrap.servers=${spring.embedded.kafka.brokers}', 'elasticsearch.index.prefix=MigrationIntegrationTest'])
+@TestPropertySource(properties = ['kafka.bootstrap.servers=${spring.embedded.kafka.brokers}'])
 class MigrationIntegrationTest extends Specification {
 
   @LocalServerPort

--- a/admin/src/integrationTest/groovy/org/cedar/onestop/api/admin/MigrationIntegrationTest.groovy
+++ b/admin/src/integrationTest/groovy/org/cedar/onestop/api/admin/MigrationIntegrationTest.groovy
@@ -25,7 +25,8 @@ import org.springframework.test.context.TestPropertySource
 import org.springframework.web.client.RestTemplate
 import spock.lang.Specification
 
-import static org.cedar.onestop.elastic.common.DocumentUtil.*
+import static org.cedar.onestop.elastic.common.DocumentUtil.getFileIdentifier
+import static org.cedar.onestop.elastic.common.DocumentUtil.getInternalParentIdentifier
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
 
 @DirtiesContext
@@ -41,7 +42,7 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
     webEnvironment = RANDOM_PORT
 )
 @Slf4j
-@TestPropertySource(properties = ['kafka.bootstrap.servers=${spring.embedded.kafka.brokers}'])
+@TestPropertySource(properties = ['kafka.bootstrap.servers=${spring.embedded.kafka.brokers}', 'elasticsearch.index.prefix=MigrationIntegrationTest'])
 class MigrationIntegrationTest extends Specification {
 
   @LocalServerPort

--- a/search/build.gradle
+++ b/search/build.gradle
@@ -152,6 +152,7 @@ sourceSets {
 }
 
 task integrationTest(type: Test) {
+  dependsOn { jks }
 
   doFirst {
     // `CI` env var is typically "true" inside CircleCI, Travis, and other CI environments.


### PR DESCRIPTION
Simplify the build:
- Still builds the subprojects in parallel jobs
- Each job does all the steps for its subproject, rather than handing off between multiple jobs
- Test result capturing is working for the `admin` and `search` jobs
- `e2e` and `check-owasp-cve` now *only* run as part of the nightly build

Possible future improvements:
- The caching still does not seem to be fully functional, e.g. the `checkout` job is still downloading gradle every time
- The `finalize` step incurs nearly a full minute of time to attach the workspace from previous steps... but all it's doing is publishing to codecov and saving the cache. A possible future approach is:
    - Publish codecov info in each of the `admin`, `client` and `search` jobs, see if codecov can stitch the reports together?
    - Split the single cache into separate ones for each subproject and save it at the end of each subproject job?