### PR TITLE
1029 update circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,12 +7,12 @@ defaults: &defaults
   docker:
     - image: circleci/openjdk:11-jdk
   environment:
-    - GRADLE_USER_HOME: $HOME/repo/.gradle_home
+    - GRADLE_USER_HOME: .gradle_home
   working_directory: ~/repo
 
 defaultsWithElasticsearch: &defaultsWithElasticsearch
   environment:
-    - GRADLE_USER_HOME: $HOME/repo/.gradle_home
+    - GRADLE_USER_HOME: .gradle_home
   docker:
     - image: circleci/openjdk:11-jdk # primary container to issue gradle commands from
     - image: docker.elastic.co/elasticsearch/elasticsearch:6.8.2
@@ -40,9 +40,9 @@ restoreCache: &restoreCache
   # Download and cache dependencies
   restore_cache:
     keys:
-      - onestop-cache-v14-{{ checksum "build.gradle" }}-{{ checksum "admin/build.gradle" }}-{{ checksum "client/build.gradle" }}-{{ checksum "client/package.json" }}-{{ checksum "registry/build.gradle" }}-{{ checksum "search/build.gradle" }}-{{ checksum "stream-manager/build.gradle" }}
+      - onestop-cache-v15-{{ checksum "build.gradle" }}-{{ checksum "admin/build.gradle" }}-{{ checksum "client/build.gradle" }}-{{ checksum "client/package.json" }}-{{ checksum "registry/build.gradle" }}-{{ checksum "search/build.gradle" }}-{{ checksum "stream-manager/build.gradle" }}
       # fallback to using the latest cache if no exact match is found
-      - onestop-cache-v14-
+      - onestop-cache-v15-
 
 saveCache: &saveCache
   save_cache:
@@ -57,7 +57,7 @@ saveCache: &saveCache
       - registry/build
       - search/build
       - stream-manager/build
-    key: onestop-cache-v14-{{ checksum "build.gradle" }}-{{ checksum "admin/build.gradle" }}-{{ checksum "client/build.gradle" }}-{{ checksum "client/package.json" }}-{{ checksum "registry/build.gradle" }}-{{ checksum "search/build.gradle" }}-{{ checksum "stream-manager/build.gradle" }}
+    key: onestop-cache-v15-{{ checksum "build.gradle" }}-{{ checksum "admin/build.gradle" }}-{{ checksum "client/build.gradle" }}-{{ checksum "client/package.json" }}-{{ checksum "registry/build.gradle" }}-{{ checksum "search/build.gradle" }}-{{ checksum "stream-manager/build.gradle" }}
 
 attachWorkspace: &attachWorkspace
   - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
           name: Generate Coverage Reports
           command: ./gradlew admin:jacocoTestReport -x test
       - run:
-          name: Collect Test Reports
+          name: Collect Test Results
           command: |
             mkdir -p ~/tests/junit/
             find admin/ -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/tests/junit/ \;
@@ -147,7 +147,7 @@ jobs:
           name: Generate Coverage Report
           command: ./gradlew search:jacocoTestReport -x test
       - run:
-          name: Collect Test Reports
+          name: Collect Test Results
           command: |
             mkdir -p ~/tests/junit/
             find search/ -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/tests/junit/ \;
@@ -156,7 +156,7 @@ jobs:
       - store_test_results:
           path: ~/tests
       - store_artifacts:
-          path: build/search/reports
+          path: search/build/reports
       - deploy:
           name: Publish Image(s)
           command: |
@@ -179,7 +179,7 @@ jobs:
           name: Assemble, Check, Report
           command: ./gradlew --parallel client:assemble client:check
       - run:
-          name: Collect Test Reports
+          name: Collect Test Results
           command: |
             mkdir -p ~/tests/junit/
             find client/ -type f -regex ".*/build/junit/.*xml" -exec cp {} ~/tests/junit/ \;
@@ -210,7 +210,7 @@ jobs:
         name: Assemble, Check, Report
         command: ./gradlew --parallel registry:assemble registry:check registry:jacocoTestReport
     - run:
-        name: Collect Test Reports
+        name: Collect Test Results
         command: |
           mkdir -p ~/tests/junit/
           find registry/ -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/tests/junit/ \;
@@ -243,7 +243,7 @@ jobs:
         name: Assemble, Check, Report
         command: ./gradlew --parallel stream-manager:assemble stream-manager:check stream-manager:jacocoTestReport
     - run:
-        name: Collect Test Reports
+        name: Collect Test Results
         command: |
           mkdir -p ~/tests/junit/
           find stream-manager/ -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/tests/junit/ \;
@@ -272,15 +272,6 @@ jobs:
     steps:
       - <<: *attachWorkspace
       - run:
-          name: Collect Coverage Results
-          command: |
-            mkdir -p ~/tests/coverage/
-            find . -type d -regex ".*/build/reports/jacoco/" -exec cp -r {} ~/tests/coverage/ \;
-            find . -type d -regex ".*/build/coverage/lcov-report/" -exec cp -r {} ~/tests/coverage/ \;
-          when: always
-      - store_artifacts:
-          path: ~/tests/coverage
-      - run:
           name: Post coverage results to codecov
           command: |
             bash <(curl -s https://codecov.io/bash)
@@ -292,7 +283,7 @@ jobs:
       - <<: *attachWorkspace
       - run:
           name: Run OWASP Check
-          command: ./gradlew dependencyCheckAggregate
+          command: ./gradlew dependencyCheckUpdate dependencyCheckAggregate
           no_output_timeout: 30m
       - store_artifacts:
           path: build/reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ defaults: &defaults
   docker:
     - image: circleci/openjdk:11-jdk
   environment:
-    - GRADLE_USER_HOME: ~/repo/.gradle_home
+    - GRADLE_USER_HOME: $HOME/repo/.gradle_home
   working_directory: ~/repo
 
 defaultsWithElasticsearch: &defaultsWithElasticsearch
@@ -40,9 +40,9 @@ restoreCache: &restoreCache
   # Download and cache dependencies
   restore_cache:
     keys:
-      - onestop-cache-v13-{{ checksum "build.gradle" }}-{{ checksum "admin/build.gradle" }}-{{ checksum "client/build.gradle" }}-{{ checksum "client/package.json" }}-{{ checksum "registry/build.gradle" }}-{{ checksum "search/build.gradle" }}-{{ checksum "stream-manager/build.gradle" }}
+      - onestop-cache-v14-{{ checksum "build.gradle" }}-{{ checksum "admin/build.gradle" }}-{{ checksum "client/build.gradle" }}-{{ checksum "client/package.json" }}-{{ checksum "registry/build.gradle" }}-{{ checksum "search/build.gradle" }}-{{ checksum "stream-manager/build.gradle" }}
       # fallback to using the latest cache if no exact match is found
-      - onestop-cache-v13-
+      - onestop-cache-v14-
 
 saveCache: &saveCache
   save_cache:
@@ -57,7 +57,7 @@ saveCache: &saveCache
       - registry/build
       - search/build
       - stream-manager/build
-    key: onestop-cache-v13-{{ checksum "build.gradle" }}-{{ checksum "admin/build.gradle" }}-{{ checksum "client/build.gradle" }}-{{ checksum "client/package.json" }}-{{ checksum "registry/build.gradle" }}-{{ checksum "search/build.gradle" }}-{{ checksum "stream-manager/build.gradle" }}
+    key: onestop-cache-v14-{{ checksum "build.gradle" }}-{{ checksum "admin/build.gradle" }}-{{ checksum "client/build.gradle" }}-{{ checksum "client/package.json" }}-{{ checksum "registry/build.gradle" }}-{{ checksum "search/build.gradle" }}-{{ checksum "stream-manager/build.gradle" }}
 
 attachWorkspace: &attachWorkspace
   - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ defaults: &defaults
 
 defaultsWithElasticsearch: &defaultsWithElasticsearch
   environment:
-    - GRADLE_USER_HOME: ~/repo/.gradle_home
+    - GRADLE_USER_HOME: $HOME/repo/.gradle_home
   docker:
     - image: circleci/openjdk:11-jdk # primary container to issue gradle commands from
     - image: docker.elastic.co/elasticsearch/elasticsearch:6.8.2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,9 +40,9 @@ restoreCache: &restoreCache
   # Download and cache dependencies
   restore_cache:
     keys:
-      - onestop-cache-v12-{{ checksum "build.gradle" }}-{{ checksum "admin/build.gradle" }}-{{ checksum "client/build.gradle" }}-{{ checksum "client/package.json" }}-{{ checksum "search/build.gradle" }}
+      - onestop-cache-v13-{{ checksum "build.gradle" }}-{{ checksum "admin/build.gradle" }}-{{ checksum "client/build.gradle" }}-{{ checksum "client/package.json" }}-{{ checksum "registry/build.gradle" }}-{{ checksum "search/build.gradle" }}-{{ checksum "stream-manager/build.gradle" }}
       # fallback to using the latest cache if no exact match is found
-      - onestop-cache-v12-
+      - onestop-cache-v13-
 
 saveCache: &saveCache
   save_cache:
@@ -54,8 +54,10 @@ saveCache: &saveCache
       - client/build
       - client/.gradle
       - client/node_modules
+      - registry/build
       - search/build
-    key: onestop-cache-v12-{{ checksum "build.gradle" }}-{{ checksum "admin/build.gradle" }}-{{ checksum "client/build.gradle" }}-{{ checksum "client/package.json" }}-{{ checksum "search/build.gradle" }}
+      - stream-manager/build
+    key: onestop-cache-v13-{{ checksum "build.gradle" }}-{{ checksum "admin/build.gradle" }}-{{ checksum "client/build.gradle" }}-{{ checksum "client/package.json" }}-{{ checksum "registry/build.gradle" }}-{{ checksum "search/build.gradle" }}-{{ checksum "stream-manager/build.gradle" }}
 
 attachWorkspace: &attachWorkspace
   - attach_workspace:
@@ -71,20 +73,15 @@ jobs:
             - source-v1-{{ .Branch }}-{{ .Revision }}
             - source-v1-{{ .Branch }}-
             - source-v1-
-
       - checkout
-
       - save_cache:
           key: source-v1-{{ .Branch }}-{{ .Revision }}
           paths:
             - ".git"
-
       - <<: *restoreCache
-
       - run:
           name: Build shared resources
-          command: ./gradlew --parallel elastic-common:build
-
+          command: ./gradlew --parallel elastic-common:build kafka-common:build
       - persist_to_workspace:
           root: ~/repo
           paths:
@@ -93,26 +90,20 @@ jobs:
   admin:
     <<: *defaultsWithElasticsearch
     <<: *env
-
     steps:
       - <<: *attachWorkspace
-
       - run:
           name: Assemble, Check (sans integration tests)
           command: ./gradlew --parallel admin:assemble admin:check -x integrationTest
-
       - run:
           name: Wait for Elasticsearch
           command: dockerize -wait tcp://localhost:9200 -timeout 1m
-
       - run:
           name: Integration Tests
           command: ./gradlew admin:integrationTest
-
       - run:
           name: Test Reports
           command: ./gradlew admin:jacocoTestReport -x test
-
       - run:
           name: Save test results
           command: |
@@ -121,13 +112,10 @@ jobs:
             find . -type f -regex "admin/build/integration-test-results/.*xml" -exec cp {} ~/tests/junit/ \;
             find . -type f -regex "admin/build/coverage/junit/.*xml" -exec cp {} ~/tests/junit/ \;
           when: always
-
       - store_test_results:
           path: ~/tests
-
       - store_artifacts:
           path: ~/tests
-
       - deploy:
           name: Publish Image(s)
           command: |
@@ -137,7 +125,6 @@ jobs:
             else
               echo "Skipping publishing"
             fi
-
       - persist_to_workspace:
           root: ~/repo
           paths:
@@ -146,26 +133,20 @@ jobs:
   search:
     <<: *defaultsWithElasticsearch
     <<: *env
-
     steps:
       - <<: *attachWorkspace
-
       - run:
           name: Assemble, Check (sans integration tests)
           command: ./gradlew --parallel search:assemble search:check -x integrationTest
-
       - run:
           name: Wait for Elasticsearch
           command: dockerize -wait tcp://localhost:9200 -timeout 1m
-
       - run:
           name: Integration Tests
           command: ./gradlew search:integrationTest
-
       - run:
           name: Test Reports
           command: ./gradlew search:jacocoTestReport -x test
-
       - run:
           name: Save test results
           command: |
@@ -174,13 +155,10 @@ jobs:
             find . -type f -regex "search/build/integration-test-results/.*xml" -exec cp {} ~/tests/junit/ \;
             find . -type f -regex "search/build/coverage/junit/.*xml" -exec cp {} ~/tests/junit/ \;
           when: always
-
       - store_test_results:
           path: ~/tests
-
       - store_artifacts:
           path: ~/tests
-
       - deploy:
           name: Publish Image(s)
           command: |
@@ -190,7 +168,6 @@ jobs:
             else
               echo "Skipping publishing"
             fi
-
       - persist_to_workspace:
           root: ~/repo
           paths:
@@ -200,11 +177,9 @@ jobs:
     <<: *defaults
     steps:
       - <<: *attachWorkspace
-
       - run:
           name: Assemble, Check
           command: ./gradlew --parallel client:assemble client:check
-
       - deploy:
           name: Publish Image(s)
           command: |
@@ -214,19 +189,91 @@ jobs:
             else
               echo "Skipping publishing"
             fi
-
       - persist_to_workspace:
           root: ~/repo
           paths:
             - client/build
             - client/node_modules
-            -
+
+
+  registry:
+    <<: *defaults
+    <<: *env
+    steps:
+    - <<: *attachWorkspace
+    - run:
+        name: Assemble, Check (sans integration tests)
+        command: ./gradlew --parallel registry:assemble registry:check
+    - run:
+        name: Test Reports
+        command: ./gradlew registry:jacocoTestReport -x test
+    - run:
+        name: Save test results
+        command: |
+          mkdir -p ~/tests/junit/
+          find . -type f -regex "registry/build/test-results/.*xml" -exec cp {} ~/tests/junit/ \;
+          find . -type f -regex "registry/build/integration-test-results/.*xml" -exec cp {} ~/tests/junit/ \;
+          find . -type f -regex "registry/build/coverage/junit/.*xml" -exec cp {} ~/tests/junit/ \;
+        when: always
+    - store_test_results:
+        path: ~/tests
+    - store_artifacts:
+        path: ~/tests
+    - deploy:
+        name: Publish Image(s)
+        command: |
+          echo "${CIRCLE_BRANCH}"
+          if [[ "${CIRCLE_BRANCH}" == "master" ]] || [[ "${CIRCLE_BRANCH}" == release* ]]; then
+            ./gradlew registry:jib
+          else
+            echo "Skipping publishing"
+          fi
+    - persist_to_workspace:
+        root: ~/repo
+        paths:
+        - registry/build
+
+  stream-manager:
+    <<: *defaults
+    <<: *env
+    steps:
+    - <<: *attachWorkspace
+    - run:
+        name: Assemble, Check (sans integration tests)
+        command: ./gradlew --parallel stream-manager:assemble stream-manager:check
+    - run:
+        name: Test Reports
+        command: ./gradlew stream-manager:jacocoTestReport -x test
+    - run:
+        name: Save test results
+        command: |
+          mkdir -p ~/tests/junit/
+          find . -type f -regex "stream-manager/build/test-results/.*xml" -exec cp {} ~/tests/junit/ \;
+          find . -type f -regex "stream-manager/build/integration-test-results/.*xml" -exec cp {} ~/tests/junit/ \;
+          find . -type f -regex "stream-manager/build/coverage/junit/.*xml" -exec cp {} ~/tests/junit/ \;
+        when: always
+    - store_test_results:
+        path: ~/tests
+    - store_artifacts:
+        path: ~/tests
+    - deploy:
+        name: Publish Image(s)
+        command: |
+          echo "${CIRCLE_BRANCH}"
+          if [[ "${CIRCLE_BRANCH}" == "master" ]] || [[ "${CIRCLE_BRANCH}" == release* ]]; then
+            ./gradlew stream-manager:jib
+          else
+            echo "Skipping publishing"
+          fi
+    - persist_to_workspace:
+        root: ~/repo
+        paths:
+        - stream-manager/build
+
   finalize:
     <<: *defaults
-
     steps:
       - <<: *attachWorkspace
-
       - run:
           name: Save coverage results
           command: |
@@ -234,39 +281,24 @@ jobs:
             find . -type d -regex ".*/build/reports/jacoco/" -exec cp -r {} ~/tests/coverage/ \;
             find . -type d -regex ".*/build/coverage/lcov-report/" -exec cp -r {} ~/tests/coverage/ \;
           when: always
-
       - store_artifacts:
           path: ~/tests/coverage
-
       - run:
           name: Post coverage results to codecov
           command: |
             bash <(curl -s https://codecov.io/bash)
-
       - <<: *saveCache
 
   check-owasp-cve:
     <<: *defaults
-
     steps:
       - <<: *attachWorkspace
-
       - run:
           name: Run OWASP Check
-          command: ./gradlew dependencyCheckAnalyze
+          command: ./gradlew dependencyCheckAggregate
           no_output_timeout: 30m
-
-      - run:
-          name: Save OWASP results
-          command: |
-            mkdir -p ~/owasp/admin/
-            find . -type d -regex "admin/build/reports/dependency-check-report.html" -exec cp -r {} ~/owasp/admin/ \;
-            mkdir -p ~/owasp/search/
-            find . -type d -regex "search/build/reports/dependency-check-report.html" -exec cp -r {} ~/owasp/search/ \;
-          when: always
-
       - store_artifacts:
-          path: ~/owasp
+          path: build/reports
 
   e2e:
     <<: *defaultsMachine
@@ -315,14 +347,22 @@ workflows:
       - client:
           requires:
             - checkout
+      - registry:
+          requires:
+            - checkout
       - search:
+          requires:
+            - checkout
+      - stream-manager:
           requires:
             - checkout
       - finalize:
           requires:
             - admin
             - client
+            - registry
             - search
+            - stream-manager
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,7 +360,6 @@ workflows:
             branches:
               only:
                 - master
-                - 1029-updateCircle
     jobs:
       - checkout
       - check-owasp-cve:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,6 +360,7 @@ workflows:
             branches:
               only:
                 - master
+                - 1029-updateCircle
     jobs:
       - checkout
       - check-owasp-cve:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,20 +102,19 @@ jobs:
           name: Integration Tests
           command: ./gradlew admin:integrationTest
       - run:
-          name: Test Reports
+          name: Generate Coverage Reports
           command: ./gradlew admin:jacocoTestReport -x test
       - run:
-          name: Save test results
+          name: Collect Test Reports
           command: |
             mkdir -p ~/tests/junit/
-            find . -type f -regex "admin/build/test-results/.*xml" -exec cp {} ~/tests/junit/ \;
-            find . -type f -regex "admin/build/integration-test-results/.*xml" -exec cp {} ~/tests/junit/ \;
-            find . -type f -regex "admin/build/coverage/junit/.*xml" -exec cp {} ~/tests/junit/ \;
+            find admin/ -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/tests/junit/ \;
+            find admin/ -type f -regex ".*/build/integration-test-results/.*xml" -exec cp {} ~/tests/junit/ \;
           when: always
       - store_test_results:
           path: ~/tests
       - store_artifacts:
-          path: ~/tests
+          path: admin/build/reports
       - deploy:
           name: Publish Image(s)
           command: |
@@ -145,20 +144,19 @@ jobs:
           name: Integration Tests
           command: ./gradlew search:integrationTest
       - run:
-          name: Test Reports
+          name: Generate Coverage Report
           command: ./gradlew search:jacocoTestReport -x test
       - run:
-          name: Save test results
+          name: Collect Test Reports
           command: |
             mkdir -p ~/tests/junit/
-            find . -type f -regex "search/build/test-results/.*xml" -exec cp {} ~/tests/junit/ \;
-            find . -type f -regex "search/build/integration-test-results/.*xml" -exec cp {} ~/tests/junit/ \;
-            find . -type f -regex "search/build/coverage/junit/.*xml" -exec cp {} ~/tests/junit/ \;
+            find search/ -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/tests/junit/ \;
+            find search/ -type f -regex ".*/build/integration-test-results/.*xml" -exec cp {} ~/tests/junit/ \;
           when: always
       - store_test_results:
           path: ~/tests
       - store_artifacts:
-          path: ~/tests
+          path: build/search/reports
       - deploy:
           name: Publish Image(s)
           command: |
@@ -178,8 +176,16 @@ jobs:
     steps:
       - <<: *attachWorkspace
       - run:
-          name: Assemble, Check
+          name: Assemble, Check, Report
           command: ./gradlew --parallel client:assemble client:check
+      - run:
+          name: Collect Test Reports
+          command: |
+            mkdir -p ~/tests/junit/
+            find client/ -type f -regex ".*/build/junit/.*xml" -exec cp {} ~/tests/junit/ \;
+          when: always
+      - store_test_results:
+          path: ~/tests
       - deploy:
           name: Publish Image(s)
           command: |
@@ -195,30 +201,25 @@ jobs:
             - client/build
             - client/node_modules
 
-
   registry:
     <<: *defaults
     <<: *env
     steps:
     - <<: *attachWorkspace
     - run:
-        name: Assemble, Check (sans integration tests)
-        command: ./gradlew --parallel registry:assemble registry:check
+        name: Assemble, Check, Report
+        command: ./gradlew --parallel registry:assemble registry:check registry:jacocoTestReport
     - run:
-        name: Test Reports
-        command: ./gradlew registry:jacocoTestReport -x test
-    - run:
-        name: Save test results
+        name: Collect Test Reports
         command: |
           mkdir -p ~/tests/junit/
-          find . -type f -regex "registry/build/test-results/.*xml" -exec cp {} ~/tests/junit/ \;
-          find . -type f -regex "registry/build/integration-test-results/.*xml" -exec cp {} ~/tests/junit/ \;
-          find . -type f -regex "registry/build/coverage/junit/.*xml" -exec cp {} ~/tests/junit/ \;
+          find registry/ -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/tests/junit/ \;
+          find registry/ -type f -regex ".*/build/integration-test-results/.*xml" -exec cp {} ~/tests/junit/ \;
         when: always
     - store_test_results:
         path: ~/tests
     - store_artifacts:
-        path: ~/tests
+        path: registry/build/reports
     - deploy:
         name: Publish Image(s)
         command: |
@@ -239,23 +240,19 @@ jobs:
     steps:
     - <<: *attachWorkspace
     - run:
-        name: Assemble, Check (sans integration tests)
-        command: ./gradlew --parallel stream-manager:assemble stream-manager:check
+        name: Assemble, Check, Report
+        command: ./gradlew --parallel stream-manager:assemble stream-manager:check stream-manager:jacocoTestReport
     - run:
-        name: Test Reports
-        command: ./gradlew stream-manager:jacocoTestReport -x test
-    - run:
-        name: Save test results
+        name: Collect Test Reports
         command: |
           mkdir -p ~/tests/junit/
-          find . -type f -regex "stream-manager/build/test-results/.*xml" -exec cp {} ~/tests/junit/ \;
-          find . -type f -regex "stream-manager/build/integration-test-results/.*xml" -exec cp {} ~/tests/junit/ \;
-          find . -type f -regex "stream-manager/build/coverage/junit/.*xml" -exec cp {} ~/tests/junit/ \;
+          find stream-manager/ -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/tests/junit/ \;
+          find stream-manager/ -type f -regex ".*/build/integration-test-results/.*xml" -exec cp {} ~/tests/junit/ \;
         when: always
     - store_test_results:
         path: ~/tests
     - store_artifacts:
-        path: ~/tests
+        path: stream-manager/build/reports
     - deploy:
         name: Publish Image(s)
         command: |
@@ -275,7 +272,7 @@ jobs:
     steps:
       - <<: *attachWorkspace
       - run:
-          name: Save coverage results
+          name: Collect Coverage Results
           command: |
             mkdir -p ~/tests/coverage/
             find . -type d -regex ".*/build/reports/jacoco/" -exec cp -r {} ~/tests/coverage/ \;

--- a/client/jest.config.js
+++ b/client/jest.config.js
@@ -34,7 +34,7 @@ module.exports = {
   testMatch: [ "**/test/**/*.test.js?(x)"],
   reporters: [
     "default",
-    [ "jest-junit", { outputDirectory: "./build/coverage/junit" } ]
+    [ "jest-junit", { outputDirectory: "./build/junit" } ]
   ],
   moduleNameMapper: {
     "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/test/fileMock.js",


### PR DESCRIPTION
Updates circle config such that it:

- Builds and publishes all onestop and psi modules
- Captures all test results
- Saves html test reports as artifacts
- Publishes coverage reports for all tests
- **Actually caches the gradle home directory**

Resolves #1029 