### PR TITLE
Owasp jan8 2020

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ defaultsWithElasticsearch: &defaultsWithElasticsearch
     - GRADLE_USER_HOME: /home/circleci/repo/.gradle_home
   docker:
     - image: circleci/openjdk:11-jdk # primary container to issue gradle commands from
-    - image: docker.elastic.co/elasticsearch/elasticsearch:6.8.2
+    - image: docker.elastic.co/elasticsearch/elasticsearch:6.8.4
       environment:
         - cluster.name: elasticsearch-test
         - xpack.security.enabled: false

--- a/build.gradle
+++ b/build.gradle
@@ -98,8 +98,8 @@ subprojects {
         }
 
         if (details.requested.group == 'org.apache.avro' && details.requested.name == 'avro') {
-          if(details.requested.version.startsWith('1.8')) {
-            details.useVersion '1.9.1'
+          if(details.requested.version < avroVersion) {
+            details.useVersion avroVersion
             details.because 'latest avro does not depend on vulnerable jackson-mapper-asl which has not been updated since 2013'
           }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   ext {
-    springBootVersion = '2.2.0.RELEASE'
+    springBootVersion = '2.2.2.RELEASE'
     gradleNodePluginVersion = '1.3.1'
     dependencyCheckGradleVersion = '5.0.0-M3.1'
   }
@@ -37,7 +37,7 @@ subprojects {
 
   project.ext {
     schemasVersion = '0.5.0'
-    esVersion = '6.8.2'
+    esVersion = '6.8.4'
     spockVersion = '1.2-groovy-2.5'
     testContainersVersion = '1.12.2'
     groovyVersion = '2.5.8'
@@ -46,9 +46,10 @@ subprojects {
     javaxServletAPIVersion = '4.0.1'
     junitVersion = '4.12'
     auth0JavaJWT = '3.4.1'
-    confluentVersion = '5.3.1'
+    confluentVersion = '5.3.2'
     kafkaVersion = '2.3.0'
     springKafkaVersion = '2.3.1.RELEASE'
+    avroVersion = '1.9.1'
   }
 
   // URL for the source code under version control from which this container image was built.
@@ -96,9 +97,16 @@ subprojects {
           }
         }
 
+        if (details.requested.group == 'org.apache.avro' && details.requested.name == 'avro') {
+          if(details.requested.version.startsWith('1.8')) {
+            details.useVersion '1.9.1'
+            details.because 'latest avro does not depend on vulnerable jackson-mapper-asl which has not been updated since 2013'
+          }
+        }
+
         if (details.requested.group == 'com.fasterxml.jackson.core' && details.requested.name == 'jackson-databind') {
-          if (details.requested.version.startsWith('2.9')) {
-            details.useVersion '2.10.0'
+          if (details.requested.version.startsWith('2.9.') || details.requested.version.startsWith('2.10.') ) {
+            details.useVersion '2.10.1'
             details.because 'fixes vulnerability in 2.9.9 and before'
           }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -152,6 +152,12 @@ subprojects {
             details.because 'fixes CVE-2019-17195'
           }
         }
+        if (details.requested.group.startsWith('org.apache.tomcat') &&
+            details.requested.name.contains('tomcat') &&
+            details.requested.version <= '9.0.29') {
+          details.useVersion '9.0.30'
+          details.because 'Enforce tomcat 9.0.20+ to avoid vulnerabilities CVE-2019-0199, CVE-2019-0232, and CVE-2019-10072'
+        }
       }
     }
 

--- a/helm/elasticsearch/values.yaml
+++ b/helm/elasticsearch/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: docker.elastic.co/elasticsearch/elasticsearch
-  tag: 6.8.2
+  tag: 6.8.4
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/helm/kibana/values.yaml
+++ b/helm/kibana/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: docker.elastic.co/kibana/kibana
-  tag: 6.8.2
+  tag: 6.8.4
   pullPolicy: IfNotPresent
 
 service:

--- a/kafka-common/build.gradle
+++ b/kafka-common/build.gradle
@@ -14,7 +14,7 @@ dependencies {
   implementation("org.codehaus.groovy:groovy:${project.groovyVersion}")
   implementation("org.codehaus.groovy:groovy-json:${project.groovyVersion}")
   implementation("org.apache.kafka:kafka-streams:${project.kafkaVersion}")
-  implementation("org.apache.avro:avro:1.9.1")
+  implementation("org.apache.avro:avro:${project.avroVersion}")
   implementation("org.slf4j:slf4j-api:1.7.25")
   implementation("ch.qos.logback:logback-classic:1.2.3")
   implementation("com.github.cedardevs.schemas:schemas-core:${project.schemasVersion}")

--- a/kafka-common/build.gradle
+++ b/kafka-common/build.gradle
@@ -14,7 +14,7 @@ dependencies {
   implementation("org.codehaus.groovy:groovy:${project.groovyVersion}")
   implementation("org.codehaus.groovy:groovy-json:${project.groovyVersion}")
   implementation("org.apache.kafka:kafka-streams:${project.kafkaVersion}")
-  implementation("org.apache.avro:avro:1.8.2")
+  implementation("org.apache.avro:avro:1.9.1")
   implementation("org.slf4j:slf4j-api:1.7.25")
   implementation("ch.qos.logback:logback-classic:1.2.3")
   implementation("com.github.cedardevs.schemas:schemas-core:${project.schemasVersion}")

--- a/owasp-suppressions.xml
+++ b/owasp-suppressions.xml
@@ -22,6 +22,23 @@
 
   <suppress>
     <notes><![CDATA[
+      Applies to FasterXML jackson-databind versions 2.9.x or earlier, while this application uses 2.10.1 via gradle
+      dependency resolution strategy
+      ]]></notes>
+    <cve>CVE-2017-17485</cve>
+    <cve>CVE-2018-5968</cve>
+    <cve>CVE-2017-7525</cve>
+    <cve>CVE-2017-15095</cve>
+    <cve>CVE-2018-14718</cve>
+    <cve>CVE-2018-1000873</cve>
+    <cve>CVE-2018-7489</cve>
+    <cve>CVE-2019-17267</cve>
+    <cve>CVE-2019-16335</cve>
+    <cve>CVE-2019-14540</cve>
+  </suppress>
+
+  <suppress>
+    <notes><![CDATA[
       Applies to spring framework versions prior to 5.0.x, which are not in use in this application
       ]]></notes>
     <cve>CVE-2016-9878</cve>

--- a/registry/build.gradle
+++ b/registry/build.gradle
@@ -35,7 +35,7 @@ dependencies {
   
   // -- CAS Authentication --
   implementation "org.pac4j:spring-webmvc-pac4j:3.2.0"
-  implementation "org.pac4j:pac4j-cas:3.8.2"
+  implementation "org.pac4j:pac4j-cas:3.8.3"
 
   //used to copy schema definitions to generate openAPI 
   schemaDefinitions ("com.github.cedardevs.schemas:schemas-core:${project.schemasVersion}")


### PR DESCRIPTION
- addresses latest CVE vulnerability checks
- included upgrade to avro 1.8.2->1.9.1 (which removed the vulnerable jackson-mapper-asl)
- we confirmed avro upgrade did not negatively affect system when having data loaded using 1.8.2, then reading in 1.9.2