### PR TITLE
Fix protocol and links

### DIFF
--- a/client/src/components/results/granules/GranuleAccessLink.jsx
+++ b/client/src/components/results/granules/GranuleAccessLink.jsx
@@ -56,7 +56,7 @@ const videoPlayButton = (
 const GranuleAccessLink = props => {
   const {link, item, itemId} = props
   const {protocol, url, displayName, linkProtocol} = link
-  const linkText = displayName ? displayName : protocol.label
+  const linkText = displayName ? displayName : linkProtocol
   const accessibleProtocolText = displayName
     ? `protocol: ${protocol.label} for ${item.title}`
     : ` for ${item.title}` // prevent duplicate reading of protocol.label if that is also used as the linkText

--- a/client/src/utils/resultUtils.js
+++ b/client/src/utils/resultUtils.js
@@ -111,7 +111,7 @@ export const protocols = Immutable([
   },
   {
     id: 'T',
-    names: [ 'thredds', 'unidata:thredds' ],
+    names: [ 'thredds', 'unidata:thredds', 'unidata:ncss', 'unidata:ncml' ],
     color: '#616161',
     label: 'THREDDS',
   },


### PR DESCRIPTION
- fallback link title is now protocol from metadata (prevent losing info when there are multiple links of same protocol type - particularly unknown ones)
- two unidata types added to THREDDS protocol category

resolves #1135

Before:
<img width="279" alt="Screen Shot 2020-02-18 at 1 18 45 PM" src="https://user-images.githubusercontent.com/8432213/74775480-0c478b80-5253-11ea-831e-dda52c8767f3.png">
After:
<img width="337" alt="Screen Shot 2020-02-18 at 1 28 00 PM" src="https://user-images.githubusercontent.com/8432213/74775483-0d78b880-5253-11ea-8e6e-0d0648d42271.png">

