### PR TITLE
Fixed typo in "In each subsection, you can use arrow keys to navigate…

### DIFF
--- a/client/src/components/filters/facet/FacetFilter.jsx
+++ b/client/src/components/filters/facet/FacetFilter.jsx
@@ -109,7 +109,7 @@ export default class FacetFilter extends React.Component {
       <div style={styleFacetFilter}>
         <div style={styleDescription}>
           <div id="facetFilterInstructions">
-            In each subsection, you can use arrow keys navigate attributes, and
+            In each subsection, you can use arrow keys to navigate attributes, and
             space or enter to toggle selections.
           </div>
         </div>


### PR DESCRIPTION
… " was missing the to word.
resolves #1176 