### PR TITLE
1248-Ensure Indices

### DIFF
--- a/indexer/src/main/java/org/cedar/onestop/indexer/util/ElasticsearchService.java
+++ b/indexer/src/main/java/org/cedar/onestop/indexer/util/ElasticsearchService.java
@@ -72,6 +72,7 @@ public class ElasticsearchService {
 
   private void ensureIndices() throws IOException {
     ensureSearchIndices();
+    ensureAnalysisAndErrorsIndices();
   }
 
   private void ensureSearchIndices() throws IOException {
@@ -81,6 +82,11 @@ public class ElasticsearchService {
     if (config.sitemapEnabled()) {
       ensureAliasWithIndex(config.SITEMAP_INDEX_ALIAS);
     }
+  }
+
+  private void ensureAnalysisAndErrorsIndices() throws IOException {
+    ensureAliasWithIndex(config.COLLECTION_ERROR_AND_ANALYSIS_INDEX_ALIAS);
+    ensureAliasWithIndex(config.GRANULE_ERROR_AND_ANALYSIS_INDEX_ALIAS);
   }
 
   private void ensureAliasWithIndex(String alias) throws IOException {


### PR DESCRIPTION
This PR resolves #1248 where it was noted that the new A&E indices were not ensured and not consistently being created when the Indexer was updated. This should fix that!