### PR TITLE
Ensure there are no breaking conflicts in mappings when starting inde…

### DIFF
--- a/docs/operator/deployment/v3/upgrade.md
+++ b/docs/operator/deployment/v3/upgrade.md
@@ -1,0 +1,9 @@
+# Upgrade the System
+
+## Elasticsearch mappings
+
+As noted by [mappings](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-put-mapping.html) and [settings](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-update-settings.html), some index changes cannot be done without a [reindex](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-reindex.html).
+
+The Indexer application is tied to the expected mapping. If an incompatible mapping change is requested, the Indexer will not be able to start up, and will exit with an error log message, indicating a reindex is required to make that change.
+
+The expected procedure is to follow the reindexing process for Elasticsearch, then to restart Indexer.

--- a/elastic-common/src/main/resources/mappings/search_flattened_granuleIndex.json
+++ b/elastic-common/src/main/resources/mappings/search_flattened_granuleIndex.json
@@ -5,7 +5,7 @@
         "filename_analyzer": {
           "type": "pattern",
           "pattern": "([^\\p{L}\\d]+)|(?<=[\\p{L}&&[^\\p{Lu}]])(?=\\p{Lu})|(?<=\\p{Lu})(?=\\p{Lu}[\\p{L}&&[^\\p{Lu}]])",
-          "lowercase": true
+          "lowercase": "true"
         }
       }
     }

--- a/elastic-common/src/main/resources/mappings/search_granuleIndex.json
+++ b/elastic-common/src/main/resources/mappings/search_granuleIndex.json
@@ -5,7 +5,7 @@
         "filename_analyzer": {
           "type": "pattern",
           "pattern": "([^\\p{L}\\d]+)|(?<=[\\p{L}&&[^\\p{Lu}]])(?=\\p{Lu})|(?<=\\p{Lu})(?=\\p{Lu}[\\p{L}&&[^\\p{Lu}]])",
-          "lowercase": true
+          "lowercase": "true"
         }
       }
     }

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -129,6 +129,28 @@ profiles:
     deploy:
       helm:
         releases:
+          - name: onestop-indexer
+            chartPath: helm/onestop-indexer
+            values:
+              image: cedardevs/onestop-indexer
+            setValues:
+              debug: true
+              elasticsearch.host: "onestop-dev-es-http"
+              elasticsearch.ssl.certSecret: "onestop-dev-es-http-certs-public"
+              elasticsearch.password.valueFrom.secretKeyRef.name: "onestop-dev-es-elastic-user"
+              config: |-
+                ---
+                kafka:
+                  bootstrap:
+                    servers: "PLAINTEXT://onestop-dev-cp-kafka:9092"
+                  schema:
+                    registry:
+                      url: "http://onestop-dev-cp-schema-registry:8081"
+                  commit:
+                    interval:
+                      ms: 1000
+            imageStrategy:
+              helm: {}
           - name: onestop-parsalyzer
             chartPath: helm/onestop-parsalyzer
             values:


### PR DESCRIPTION
…xer.

resolves #1268 

Manually tested by:

- removed a field (warning message only)
- added a new field named "fake" (warning message only)
- changed the type of a field (eg from "text" to "keyword") - error message and app quits
- added a new analyzer and changed fileIdentifier from filename_analyzer to fake_analyzer - error message and app quits
- change filename_analyzer properties (eg altered "pattern" or changed "lowercase" from "true" to "false) - error message and app quits

Doc is clear about when reindexing is required, but doesn't currently give specific instructions on how to do it. Presuming we will have to expand that for clarity if/when it comes up.