### PR TITLE
1430 search link url

### DIFF
--- a/buildSrc/src/main/kotlin/utils.kt
+++ b/buildSrc/src/main/kotlin/utils.kt
@@ -29,7 +29,7 @@ object Versions {
 
     const val GROOVY: String = "2.5.8"
     const val SPOCK: String = "1.2-groovy-2.5"
-    const val TEST_CONTAINERS: String = "1.15.0"
+    const val TEST_CONTAINERS: String = "1.15.1"
     const val OPEN_SAML = "3.4.3"
     const val LOGBACK = "1.2.3"
     const val SLF4J = "1.7.28"

--- a/elastic-common/src/main/resources/mappings/search_collectionIndex.json
+++ b/elastic-common/src/main/resources/mappings/search_collectionIndex.json
@@ -121,9 +121,7 @@
             "doc_values": false
           },
           "linkUrl": {
-            "type": "keyword",
-            "index": false,
-            "doc_values": false
+            "type": "keyword"
           },
           "linkDescription": {
             "type": "keyword",

--- a/elastic-common/src/main/resources/mappings/search_collectionIndex.json
+++ b/elastic-common/src/main/resources/mappings/search_collectionIndex.json
@@ -116,9 +116,7 @@
             "doc_values": false
           },
           "linkProtocol": {
-            "type": "keyword",
-            "index": false,
-            "doc_values": false
+            "type": "keyword"
           },
           "linkUrl": {
             "type": "keyword"

--- a/elastic-common/src/main/resources/mappings/search_flattened_granuleIndex.json
+++ b/elastic-common/src/main/resources/mappings/search_flattened_granuleIndex.json
@@ -157,9 +157,7 @@
             "doc_values": false
           },
           "linkUrl": {
-            "type": "keyword",
-            "index": false,
-            "doc_values": false
+            "type": "keyword"
           },
           "linkDescription": {
             "type": "keyword",

--- a/elastic-common/src/main/resources/mappings/search_flattened_granuleIndex.json
+++ b/elastic-common/src/main/resources/mappings/search_flattened_granuleIndex.json
@@ -152,9 +152,7 @@
             "doc_values": false
           },
           "linkProtocol": {
-            "type": "keyword",
-            "index": false,
-            "doc_values": false
+            "type": "keyword"
           },
           "linkUrl": {
             "type": "keyword"

--- a/elastic-common/src/main/resources/mappings/search_granuleIndex.json
+++ b/elastic-common/src/main/resources/mappings/search_granuleIndex.json
@@ -157,9 +157,7 @@
             "doc_values": false
           },
           "linkUrl": {
-            "type": "keyword",
-            "index": false,
-            "doc_values": false
+            "type": "keyword"
           },
           "linkDescription": {
             "type": "keyword",

--- a/elastic-common/src/main/resources/mappings/search_granuleIndex.json
+++ b/elastic-common/src/main/resources/mappings/search_granuleIndex.json
@@ -152,9 +152,7 @@
             "doc_values": false
           },
           "linkProtocol": {
-            "type": "keyword",
-            "index": false,
-            "doc_values": false
+            "type": "keyword"
           },
           "linkUrl": {
             "type": "keyword"

--- a/elastic-common/src/test/resources/test/data/generic/field_query/bulkData.txt
+++ b/elastic-common/src/test/resources/test/data/generic/field_query/bulkData.txt
@@ -1,0 +1,10 @@
+{ "index": { "_index": "field_query", "_id": "1" } }
+{ "fileFormat": "NetCDF", "dataFormats": [{ "version": "4", "name": "NETCDF" }], "links":[{"linkFunction":"download","linkUrl":"s3://noaa-goes16/1111.nc","linkName":"Amazon S3","linkProtocol":"HTTPS"}] }
+{ "index": { "_index": "field_query", "_id": "2" } }
+{ "fileFormat": "NetCDF", "dataFormats": [{ "version": "4", "name": "NETCDF" }], "links":[{"linkFunction":"download","linkUrl":"s3://noaa-goes16/2222.nc","linkName":"Amazon S3","linkProtocol":"HTTPS"}] }
+{ "index": { "_index": "field_query", "_id": "3" } }
+{ "fileFormat": "NetCDF", "dataFormats": [{ "version": "4", "name": "NETCDF" }], "links":[{"linkFunction":"download","linkUrl":"s3://noaa-goes16/3333.nc","linkName":"Amazon S3","linkProtocol":"HTTPS"}] }
+{ "index": { "_index": "field_query", "_id": "4" } }
+{ "fileFormat": "NetCDF", "dataFormats": [{ "version": "4", "name": "NETCDF" }], "links":[{"linkFunction":"download","linkUrl":"s3://noaa-goes16/4444.nc","linkName":"Amazon S3","linkProtocol":"HTTPS"}] }
+{ "index": { "_index": "field_query", "_id": "5" } }
+{ "fileFormat": "NetCDF", "dataFormats": [{ "version": "4", "name": "NETCDF" }], "links":[{"linkFunction":"download","linkUrl":"s3://noaa-goes16/5555.nc","linkName":"Amazon S3","linkProtocol":"HTTPS"}] }

--- a/elastic-common/src/test/resources/test/data/generic/field_query/bulkDataES6.txt
+++ b/elastic-common/src/test/resources/test/data/generic/field_query/bulkDataES6.txt
@@ -1,0 +1,10 @@
+{ "index": { "_index": "field_query", "_type": "_doc", "_id": "1" } }
+{ "fileFormat": "NetCDF", "dataFormats": [{ "version": "4", "name": "NETCDF" }], "links":[{"linkFunction":"download","linkUrl":"s3://noaa-goes16/1111.nc","linkName":"Amazon S3","linkProtocol":"HTTPS"}] }
+{ "index": { "_index": "field_query", "_type": "_doc", "_id": "2" } }
+{ "fileFormat": "NetCDF", "dataFormats": [{ "version": "4", "name": "NETCDF" }], "links":[{"linkFunction":"download","linkUrl":"s3://noaa-goes16/2222.nc","linkName":"Amazon S3","linkProtocol":"HTTPS"}] }
+{ "index": { "_index": "field_query", "_type": "_doc", "_id": "3" } }
+{ "fileFormat": "NetCDF", "dataFormats": [{ "version": "4", "name": "NETCDF" }], "links":[{"linkFunction":"download","linkUrl":"s3://noaa-goes16/3333.nc","linkName":"Amazon S3","linkProtocol":"HTTPS"}] }
+{ "index": { "_index": "field_query", "_type": "_doc", "_id": "4" } }
+{ "fileFormat": "NetCDF", "dataFormats": [{ "version": "4", "name": "NETCDF" }], "links":[{"linkFunction":"download","linkUrl":"s3://noaa-goes16/4444.nc","linkName":"Amazon S3","linkProtocol":"HTTPS"}] }
+{ "index": { "_index": "field_query", "_type": "_doc", "_id": "5" } }
+{ "fileFormat": "NetCDF", "dataFormats": [{ "version": "4", "name": "NETCDF" }], "links":[{"linkFunction":"download","linkUrl":"s3://noaa-goes16/5555.nc","linkName":"Amazon S3","linkProtocol":"HTTPS"}] }

--- a/elastic-common/src/test/resources/test/data/generic/field_query/index.json
+++ b/elastic-common/src/test/resources/test/data/generic/field_query/index.json
@@ -1,0 +1,47 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "fileFormat": {
+        "type": "keyword"
+      },
+      "dataFormats": {
+        "type": "nested",
+        "properties": {
+          "name": {
+            "type": "keyword"
+          },
+          "version": {
+            "type": "keyword"
+          }
+        }
+      },
+      "links": {
+        "type": "nested",
+        "properties": {
+          "linkName": {
+            "type": "keyword",
+            "index": false,
+            "doc_values": false
+          },
+          "linkProtocol": {
+            "type": "keyword",
+            "index": false,
+            "doc_values": false
+          },
+          "linkUrl": {
+            "type": "keyword"
+          },
+          "linkDescription": {
+            "type": "keyword",
+            "index": false,
+            "doc_values": false
+          },
+          "linkFunction": {
+            "type": "keyword"
+          }
+        }
+      }
+    }
+  }
+}

--- a/search/src/integrationTest/groovy/org/cedar/onestop/api/search/FieldQueryIntegrationTests.groovy
+++ b/search/src/integrationTest/groovy/org/cedar/onestop/api/search/FieldQueryIntegrationTests.groovy
@@ -1,0 +1,56 @@
+package org.cedar.onestop.api.search
+
+import org.cedar.onestop.api.search.service.ElasticsearchService
+import org.cedar.onestop.elastic.common.ElasticsearchTestConfig
+import org.elasticsearch.client.RestHighLevelClient
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
+
+@DirtiesContext
+@ActiveProfiles(["integration"])
+@SpringBootTest(
+    classes = [Application, ElasticsearchTestConfig],
+    webEnvironment = RANDOM_PORT,
+    properties = ["elasticsearch.index.prefix=search_field_query_"]
+)
+@Unroll
+class FieldQueryIntegrationTests extends Specification {
+    static private final String FIELD_QUERY_ALIAS = 'field_query'
+
+    @Autowired
+    RestHighLevelClient restHighLevelClient
+
+    @Autowired
+    ElasticsearchService esService
+
+    void setup() {
+        TestUtil.resetLoadAndRefreshGenericTestIndex(FIELD_QUERY_ALIAS, restHighLevelClient, esService)
+    }
+
+    def 'Can search by nested field'() {
+        // Null spatial boundings should not be excluded
+        given:
+        def requestParams = [
+            queries: [[
+                          type : 'fieldQuery',
+                          field: 'links.linkUrl',
+                          value: 's3://noaa-goes16/1111.nc'
+                      ]],
+            summary: false
+        ]
+
+        when:
+        def queryResponse = esService.searchFromRequest(requestParams, FIELD_QUERY_ALIAS)
+
+        then:
+        def actualMatchingIds = queryResponse.data.collect { it.id }
+        actualMatchingIds.size() == 1
+        actualMatchingIds.contains('1')
+    }
+}

--- a/search/src/integrationTest/groovy/org/cedar/onestop/api/search/FieldQueryIntegrationTests.groovy
+++ b/search/src/integrationTest/groovy/org/cedar/onestop/api/search/FieldQueryIntegrationTests.groovy
@@ -21,36 +21,38 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 )
 @Unroll
 class FieldQueryIntegrationTests extends Specification {
-    static private final String FIELD_QUERY_ALIAS = 'field_query'
+  static private final String FIELD_QUERY_ALIAS = 'field_query'
 
-    @Autowired
-    RestHighLevelClient restHighLevelClient
+  @Autowired
+  RestHighLevelClient restHighLevelClient
 
-    @Autowired
-    ElasticsearchService esService
+  @Autowired
+  ElasticsearchService esService
 
-    void setup() {
-        TestUtil.resetLoadAndRefreshGenericTestIndex(FIELD_QUERY_ALIAS, restHighLevelClient, esService)
-    }
+  void setup() {
+    TestUtil.resetLoadAndRefreshGenericTestIndex(FIELD_QUERY_ALIAS, restHighLevelClient, esService)
+  }
 
-    def 'Can search by nested field'() {
-        // Null spatial boundings should not be excluded
-        given:
-        def requestParams = [
-            queries: [[
-                          type : 'fieldQuery',
-                          field: 'links.linkUrl',
-                          value: 's3://noaa-goes16/1111.nc'
-                      ]],
-            summary: false
-        ]
+  def 'Can search by nested field'() {
+    // Null spatial boundings should not be excluded
+    given:
+    def requestParams = [
+        filters: [
+            [
+                type : 'field',
+                name : 'links.linkUrl',
+                value: 's3://noaa-goes16/1111.nc'
+            ]
+        ],
+        summary: false
+    ]
 
-        when:
-        def queryResponse = esService.searchFromRequest(requestParams, FIELD_QUERY_ALIAS)
+    when:
+    def queryResponse = esService.searchFromRequest(requestParams, FIELD_QUERY_ALIAS)
 
-        then:
-        def actualMatchingIds = queryResponse.data.collect { it.id }
-        actualMatchingIds.size() == 1
-        actualMatchingIds.contains('1')
-    }
+    then:
+    def actualMatchingIds = queryResponse.data.collect { it.id }
+    actualMatchingIds.size() == 1
+    actualMatchingIds.contains('1')
+  }
 }

--- a/search/src/main/groovy/org/cedar/onestop/api/search/service/SearchRequestParserService.groovy
+++ b/search/src/main/groovy/org/cedar/onestop/api/search/service/SearchRequestParserService.groovy
@@ -121,6 +121,11 @@ class SearchRequestParserService {
         // Add as individual objects since each request can reference a different field
         allTextQueries.add(constructGranuleNameComponent(it))
       }
+
+      groupedQueries.fieldQuery.each {
+        // As above, add as individual objects since each request can reference a different field
+        allTextQueries.add(constructFieldQueryComponent(it))
+      }
     }
 
     return [[
@@ -480,6 +485,32 @@ class SearchRequestParserService {
             fields: fields,
             operator: operator,
             type: 'cross_fields'
+        ]
+    ]
+  }
+
+  private static Map constructFieldQueryComponent(Map request) {
+    Boolean exactMatch = request.exactMatch != null ? request.exactMatch : true
+    String fieldName = request.field
+    String[] nestedParts = fieldName.split(/\./, 2)
+    String queryType = exactMatch ? 'term' : 'wildcard'
+
+    if (nestedParts.length == 1) {
+      return [
+          (queryType): [
+              (fieldName): request.value
+          ]
+      ]
+    }
+    String path = nestedParts[0]
+    return [
+        nested: [
+            path : path,
+            query: [
+                (queryType): [
+                    (fieldName): request.value
+                ]
+            ]
         ]
     ]
   }

--- a/search/src/main/java/org/cedar/onestop/api/search/service/DocumentationService.java
+++ b/search/src/main/java/org/cedar/onestop/api/search/service/DocumentationService.java
@@ -25,7 +25,7 @@ public class DocumentationService {
 
   static {
     facetNameMappings.put("dataFormats"         , "dataFormat");
-    facetNameMappings.put("linkProtocols"       , "linkProtocol");
+    facetNameMappings.put("linkProtocols"       , "links.linkProtocol");
     facetNameMappings.put("serviceLinkProtocols", "serviceLinkProtocol");
     facetNameMappings.put("science"             , "gcmdScience");
     facetNameMappings.put("services"            , "gcmdScienceServices");

--- a/search/src/main/resources/static/openapi.yaml
+++ b/search/src/main/resources/static/openapi.yaml
@@ -965,6 +965,7 @@ components:
               - $ref: "#/components/schemas/dateTimeFilter"
               - $ref: "#/components/schemas/yearFilter"
               - $ref: "#/components/schemas/facetFilter"
+              - $ref: "#/components/schemas/fieldFilter"
               - $ref: "#/components/schemas/geometryFilter"
               - $ref: "#/components/schemas/collectionFilter"
               - $ref: "#/components/schemas/excludeGlobalFilter"
@@ -981,7 +982,6 @@ components:
             oneOf:
               - $ref: "#/components/schemas/textQuery"
               - $ref: "#/components/schemas/granuleNameQuery"
-              - $ref: "#/components/schemas/fieldQuery"
           type: array
         summary:
           default: true
@@ -1054,7 +1054,7 @@ components:
       type: object
     checksumFilter:
       additionalProperties: false
-      description: "Filter granules by specific checksum(s)."
+      description: "Filter granules by specific checksum(s) and algorithm."
       properties:
         type:
           description: "Filter type."
@@ -1114,6 +1114,52 @@ components:
         - name
         - values
       title: "Facet Filter"
+      type: object
+    fieldFilter:
+      additionalProperties: false
+      description: "Filter by specific fields and their values. This is *not* a Lucene text search, and only includes fields that are not appropriate for a full text search. If the \"exactMatch\" parameter is set to false, you may include the wildcard characters '*' or '?' in the \"value\" parameter. "
+      properties:
+        type:
+          description: "Filter type."
+          enum:
+            - field
+        name:
+          description: "The field name to search on. This supports one level of nesting, e.g. \"links.linkUrl\". Note: you cannot perform this query on Lucene text fields such as \"filename\" or \"title\". For those cases, use the \"granuleName\" or \"queryText\" queries instead."
+          enum:
+            - fileIdentifier
+            - parentIdentifier
+            - doi
+            - gcmdScience
+            - gcmdScienceServices
+            - gcmdLocations
+            - gcmdInstruments
+            - gcmdPlatforms
+            - gcmdProjects
+            - gcmdDataCenters
+            - gcmdHorizontalResolution
+            - gcmdVerticalResolution
+            - gcmdTemporalResolution
+            - dataFormats.name
+            - dataFormats.version
+            - checksums.algorithm
+            - checksums.value
+            - links.linkName
+            - links.linkUrl
+            - links.linkFunction
+            - links.linkProtocol
+            - fileFormat
+        value:
+          description: "Text to filter with for the provided field. If \"exactMatch\" is false, this can include the wildcard characters '*' or '?'."
+          type: string
+        exactMatch:
+          description: "Controls the matching type of the provided \"value\" text. Defaults to true, meaning it will only return results that match the \"value\" exactly. If false, you can include the wildcard characters '*' or '?' to match against a pattern."
+          type: boolean
+          default: true
+      required:
+        - type
+        - name
+        - value
+      title: "Field Query"
       type: object
     geometryFilter:
       additionalProperties: false
@@ -1241,39 +1287,6 @@ components:
         - type
         - value
       title: "Granule Name Query"
-      type: object
-    fieldQuery:
-      additionalProperties: false
-      description: "Query by specific fields and their values. This is *not* a Lucene text search, and only includes fields that are not appropriate for a full text search. If the \"exactMatch\" parameter is set to false, you may include the wildcard characters '*' or '?' in the \"value\" parameter. "
-      properties:
-        type:
-          description: "Query type."
-          enum:
-            - fieldQuery
-        field:
-          description: "The field name to search on. This supports one level of nesting, e.g. \"links.linkUrl\". Note: you cannot perform this query on Lucene text fields such as \"filename\" or \"title\". For those cases, use the \"granuleName\" or \"queryText\" queries instead."
-          enum:
-            - checksums.algorithm
-            - checksums.value
-            - doi
-            - links.linkUrl
-            - links.linkFunction
-            - links.linkProtocol
-            - fileFormat
-            - dataFormats.name
-            - dataFormats.version
-        value:
-          description: "Text to search on for the provided field. If \"exactMatch\" is false, this can include the wildcard characters '*' or '?'."
-          type: string
-        exactMatch:
-          description: "Controls the matching type of the provided \"value\" text. Defaults to true, meaning it will only return results that match the \"value\" exactly. If false, you can include the wildcard characters '*' or '?' to match against a pattern."
-          type: boolean
-          default: true
-      required:
-        - type
-        - field
-        - value
-      title: "Field Query"
       type: object
     # Record field schemas
     accessFeeStatement: # TODO is this an array? # TODO description

--- a/search/src/main/resources/static/openapi.yaml
+++ b/search/src/main/resources/static/openapi.yaml
@@ -1244,20 +1244,29 @@ components:
       type: object
     fieldQuery:
       additionalProperties: false
-      description: ""
+      description: "Query by specific fields and their values. This is *not* a Lucene text search, and only includes fields that are not appropriate for a full text search. If the \"exactMatch\" parameter is set to false, you may include the wildcard characters '*' or '?' in the \"value\" parameter. "
       properties:
         type:
           description: "Query type."
           enum:
             - fieldQuery
         field:
-          description: ""
-          type: string
+          description: "The field name to search on. This supports one level of nesting, e.g. \"links.linkUrl\". Note: you cannot perform this query on Lucene text fields such as \"filename\" or \"title\". For those cases, use the \"granuleName\" or \"queryText\" queries instead."
+          enum:
+            - checksums.algorithm
+            - checksums.value
+            - doi
+            - links.linkUrl
+            - links.linkFunction
+            - links.linkProtocol
+            - fileFormat
+            - dataFormats.name
+            - dataFormats.version
         value:
-          description: ""
+          description: "Text to search on for the provided field. If \"exactMatch\" is false, this can include the wildcard characters '*' or '?'."
           type: string
         exactMatch:
-          description: ""
+          description: "Controls the matching type of the provided \"value\" text. Defaults to true, meaning it will only return results that match the \"value\" exactly. If false, you can include the wildcard characters '*' or '?' to match against a pattern."
           type: boolean
           default: true
       required:

--- a/search/src/main/resources/static/openapi.yaml
+++ b/search/src/main/resources/static/openapi.yaml
@@ -981,6 +981,7 @@ components:
             oneOf:
               - $ref: "#/components/schemas/textQuery"
               - $ref: "#/components/schemas/granuleNameQuery"
+              - $ref: "#/components/schemas/fieldQuery"
           type: array
         summary:
           default: true
@@ -1241,7 +1242,30 @@ components:
         - value
       title: "Granule Name Query"
       type: object
-
+    fieldQuery:
+      additionalProperties: false
+      description: ""
+      properties:
+        type:
+          description: "Query type."
+          enum:
+            - fieldQuery
+        field:
+          description: ""
+          type: string
+        value:
+          description: ""
+          type: string
+        exactMatch:
+          description: ""
+          type: boolean
+          default: true
+      required:
+        - type
+        - field
+        - value
+      title: "Field Query"
+      type: object
     # Record field schemas
     accessFeeStatement: # TODO is this an array? # TODO description
       type: string

--- a/search/src/main/resources/static/openapi.yaml
+++ b/search/src/main/resources/static/openapi.yaml
@@ -1076,7 +1076,7 @@ components:
       required:
         - type
         - values
-      title: "Collection Filter"
+      title: "Checksum Filter"
       type: object
     facetFilter:
       additionalProperties: false

--- a/search/src/test/groovy/org/cedar/onestop/api/search/service/SearchRequestParserServiceTest.groovy
+++ b/search/src/test/groovy/org/cedar/onestop/api/search/service/SearchRequestParserServiceTest.groovy
@@ -757,10 +757,17 @@ class SearchRequestParserServiceTest extends Specification {
             ]
         ],
         linkProtocols     : [
-            terms         : [
-                field: 'linkProtocol',
-                size : Integer.MAX_VALUE,
-                order: ['_term': 'asc']
+            nested: [
+                path: 'links'
+            ],
+            aggregations: [
+                foobar: [
+                    terms: [
+                        field: 'links.linkProtocol',
+                        size: Integer.MAX_VALUE,
+                        order: ['_term': 'asc']
+                    ]
+                ]
             ]
         ],
         serviceLinkProtocols: [
@@ -879,10 +886,17 @@ class SearchRequestParserServiceTest extends Specification {
           ]
         ],
         linkProtocols     : [
-            terms         : [
-                field: 'linkProtocol',
-                size : Integer.MAX_VALUE,
-                order: ['_term': 'asc']
+            nested: [
+                path: 'links'
+            ],
+            aggregations: [
+                foobar: [
+                    terms: [
+                        field: 'links.linkProtocol',
+                        size: Integer.MAX_VALUE,
+                        order: ['_term': 'asc']
+                    ]
+                ]
             ]
         ],
         serviceLinkProtocols: [

--- a/search/src/test/groovy/org/cedar/onestop/api/search/service/SearchRequestParserServiceTest.groovy
+++ b/search/src/test/groovy/org/cedar/onestop/api/search/service/SearchRequestParserServiceTest.groovy
@@ -30,24 +30,24 @@ class SearchRequestParserServiceTest extends Specification {
     yearFilters.size() == 1
 
     where:
-    type | relation | relative
-    'year' | 'intersects' | 'after'
-    'year' | 'intersects' | 'before'
-    'year' | 'disjoint' | 'after'
-    'year' | 'disjoint' | 'before'
-    'year' | 'contains' | 'after'
-    'year' | 'contains' | 'before'
-    'year' | 'within' | 'after'
-    'year' | 'within' | 'before'
+    type       | relation     | relative
+    'year'     | 'intersects' | 'after'
+    'year'     | 'intersects' | 'before'
+    'year'     | 'disjoint'   | 'after'
+    'year'     | 'disjoint'   | 'before'
+    'year'     | 'contains'   | 'after'
+    'year'     | 'contains'   | 'before'
+    'year'     | 'within'     | 'after'
+    'year'     | 'within'     | 'before'
 
     'datetime' | 'intersects' | 'after'
     'datetime' | 'intersects' | 'before'
-    'datetime' | 'disjoint' | 'after'
-    'datetime' | 'disjoint' | 'before'
-    'datetime' | 'contains' | 'after'
-    'datetime' | 'contains' | 'before'
-    'datetime' | 'within' | 'after'
-    'datetime' | 'within' | 'before'
+    'datetime' | 'disjoint'   | 'after'
+    'datetime' | 'disjoint'   | 'before'
+    'datetime' | 'contains'   | 'after'
+    'datetime' | 'contains'   | 'before'
+    'datetime' | 'within'     | 'after'
+    'datetime' | 'within'     | 'before'
   }
 
   def "Request with #label creates empty elasticsearch request"() {
@@ -217,10 +217,10 @@ class SearchRequestParserServiceTest extends Specification {
                             bool: [
                                 must: [[
                                            multi_match: [
-                                               query: "ghrsst goes",
-                                               fields: expectedFields,
+                                               query   : "ghrsst goes",
+                                               fields  : expectedFields,
                                                operator: expectedOperator,
-                                               type: 'cross_fields'
+                                               type    : 'cross_fields'
                                            ]]]]
                         ],
                         field_value_factor: [
@@ -241,12 +241,12 @@ class SearchRequestParserServiceTest extends Specification {
     queryResult == expectedQuery
 
     where:
-    desc | request | expectedOperator | expectedFields
-    'defaults for field and allTermsMustMatch' | '{"queries":[{"type": "granuleName", "value": "ghrsst goes"}]}' | 'OR' | ['title', 'fileIdentifier', 'filename']
-    'declared single field value' | '{"queries":[{"type": "granuleName", "value": "ghrsst goes", "field": "title" }]}' | 'OR' | ['title']
-    'declared "all" field value' | '{"queries":[{"type": "granuleName", "value": "ghrsst goes", "field": "all" }]}' | 'OR' | ['title', 'fileIdentifier', 'filename']
-    'allTermsMustMatch is false' | '{"queries":[{"type": "granuleName", "value": "ghrsst goes", "allTermsMustMatch": false }]}' | 'OR' | ['title', 'fileIdentifier', 'filename']
-    'allTermsMustMatch is true' | '{"queries":[{"type": "granuleName", "value": "ghrsst goes", "allTermsMustMatch": true }]}' | 'AND' | ['title', 'fileIdentifier', 'filename']
+    desc                                       | request                                                                                      | expectedOperator | expectedFields
+    'defaults for field and allTermsMustMatch' | '{"queries":[{"type": "granuleName", "value": "ghrsst goes"}]}'                              | 'OR'             | ['title', 'fileIdentifier', 'filename']
+    'declared single field value'              | '{"queries":[{"type": "granuleName", "value": "ghrsst goes", "field": "title" }]}'           | 'OR'             | ['title']
+    'declared "all" field value'               | '{"queries":[{"type": "granuleName", "value": "ghrsst goes", "field": "all" }]}'             | 'OR'             | ['title', 'fileIdentifier', 'filename']
+    'allTermsMustMatch is false'               | '{"queries":[{"type": "granuleName", "value": "ghrsst goes", "allTermsMustMatch": false }]}' | 'OR'             | ['title', 'fileIdentifier', 'filename']
+    'allTermsMustMatch is true'                | '{"queries":[{"type": "granuleName", "value": "ghrsst goes", "allTermsMustMatch": true }]}'  | 'AND'            | ['title', 'fileIdentifier', 'filename']
   }
 
   def 'Multiple granuleName objects build right request'() {
@@ -352,36 +352,23 @@ class SearchRequestParserServiceTest extends Specification {
     queryResult == expectedQuery
   }
 
-  def 'Test fieldQuery query'() {
+  def 'Test field filter'() {
     given:
-    def request = "{\"queries\": [{\"type\": \"fieldQuery\", \"field\": \"${field}\", \"value\": \"${value}\"}]}"
+    def request = """{"filters": [{"type": "field", "name": "$field", "value": "$value"}]}"""
     def params = slurper.parseText(request)
 
     when:
     def queryResult = requestParser.parseSearchQuery(params)
     def expectedQuery = [
         bool: [
-            must: [[
-                function_score: [
-                    query: [
-                        bool: [
-                            must: [[
-                                term: [
-                                    (field): value
-                                ]
-                            ]]
-                        ]
-                    ],
-                    field_value_factor: [
-                        field   : 'dsmmAverage',
-                        modifier: 'log1p',
-                        factor  : 1f,
-                        missing : 0
-                    ],
-                    boost_mode: 'sum'
+            must  : [:],
+            filter: [
+                [
+                    term: [
+                        (field): value
+                    ]
                 ]
-            ]],
-            filter: [:]
+            ]
         ]
     ]
 
@@ -389,45 +376,27 @@ class SearchRequestParserServiceTest extends Specification {
     queryResult == expectedQuery
 
     where:
-    field | value
+    field        | value
     'fileFormat' | 'NetCDF'
   }
 
-  def 'Test fieldQuery query with nested field'() {
+  def 'Test field filter with wildcard'() {
     given:
-    def request = "{\"queries\": [{\"type\": \"fieldQuery\", \"field\": \"${field}\", \"value\": \"${value}\"}]}"
+    def request = """{"filters": [{"type": "field", "name": "$field", "value": "$value", "exactMatch": false}]}"""
     def params = slurper.parseText(request)
 
     when:
     def queryResult = requestParser.parseSearchQuery(params)
     def expectedQuery = [
         bool: [
-            must: [[
-                function_score: [
-                    query: [
-                        bool: [
-                            must: [[
-                                nested: [
-                                    path: 'links',
-                                    query: [
-                                        term: [
-                                            (field): value
-                                        ]
-                                    ]
-                                ]
-                            ]]
-                        ]
-                    ],
-                    field_value_factor: [
-                        field   : 'dsmmAverage',
-                        modifier: 'log1p',
-                        factor  : 1f,
-                        missing : 0
-                    ],
-                    boost_mode: 'sum'
+            must  : [:],
+            filter: [
+                [
+                    wildcard: [
+                        (field): value
+                    ]
                 ]
-            ]],
-            filter: [:]
+            ]
         ]
     ]
 
@@ -435,7 +404,40 @@ class SearchRequestParserServiceTest extends Specification {
     queryResult == expectedQuery
 
     where:
-    field | value
+    field        | value
+    'fileFormat' | 'Net*'
+  }
+
+  def 'Test field filter with nested field'() {
+    given:
+    def request = """{"filters": [{"type": "field", "name": "${field}", "value": "${value}"}]}"""
+    def params = slurper.parseText(request)
+
+    when:
+    def queryResult = requestParser.parseSearchQuery(params)
+    def expectedQuery = [
+        bool: [
+            must  : [:],
+            filter: [
+                [
+                    nested: [
+                        path : 'links',
+                        query: [
+                            term: [
+                                (field): value
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ]
+    ]
+
+    then:
+    queryResult == expectedQuery
+
+    where:
+    field           | value
     'links.linkUrl' | 'http://foo.bar.com/csv/baz.csv'
   }
 
@@ -450,33 +452,33 @@ class SearchRequestParserServiceTest extends Specification {
         bool: [
             must  : [:],
             filter: [
-                [[ bool: [
+                [[bool: [
                     minimum_should_match: 1,
-                    should: [
-                        [ bool: [
+                    should              : [
+                        [bool: [
                             must: [
-                                [ range: [ beginDate: [ lte: '2011-11-11' ]] ],
-                                [ range: [ endDate: [ gte: '2010-10-10' ]] ]
+                                [range: [beginDate: [lte: '2011-11-11']]],
+                                [range: [endDate: [gte: '2010-10-10']]]
                             ]
-                        ] ],
-                        [ bool: [
-                            must: [
-                                [ range: [ endDate: [ gte: '2010-10-10' ]] ]
+                        ]],
+                        [bool: [
+                            must    : [
+                                [range: [endDate: [gte: '2010-10-10']]]
                             ],
                             must_not: [
-                                [ exists: [ field: 'beginDate' ] ]
+                                [exists: [field: 'beginDate']]
                             ]
-                        ] ],
-                        [ bool: [
-                            must: [
-                                [ range: [ beginDate: [ lte: '2011-11-11' ]] ]
+                        ]],
+                        [bool: [
+                            must    : [
+                                [range: [beginDate: [lte: '2011-11-11']]]
                             ],
                             must_not: [
-                                [ exists: [ field: 'endDate' ] ]
+                                [exists: [field: 'endDate']]
                             ]
-                        ] ]
+                        ]]
                     ]
-                ] ]]
+                ]]]
             ]
         ]
     ]
@@ -655,26 +657,26 @@ class SearchRequestParserServiceTest extends Specification {
             must  : [:],
             filter: [
                 [
-                  "nested":[
-                    "path":"checksums",
-                    "query":[
-                      "bool" : [
-                        "must" : [
-                            [ "terms" : ["checksums.algorithm" : ["SHA1"]] ],
-                            [ "terms" : ["checksums.value" : ["387cfb0cffbe6ec4547b7df61af8987126a9cae8"]] ]
+                    "nested": [
+                        "path" : "checksums",
+                        "query": [
+                            "bool": [
+                                "must": [
+                                    ["terms": ["checksums.algorithm": ["SHA1"]]],
+                                    ["terms": ["checksums.value": ["387cfb0cffbe6ec4547b7df61af8987126a9cae8"]]]
+                                ]
+                            ]
                         ]
-                      ]
                     ]
-                  ]
                 ],
                 [
-                    "nested":[
-                        "path":"checksums",
-                        "query":[
-                            "bool" : [
-                                "must" : [
-                                    [ "terms" : ["checksums.algorithm" : ["MD5"]] ],
-                                    [ "terms" : ["checksums.value" : ["970cfb0cffbe6ec4547b7df61af8987126a9cae8"]] ]
+                    "nested": [
+                        "path" : "checksums",
+                        "query": [
+                            "bool": [
+                                "must": [
+                                    ["terms": ["checksums.algorithm": ["MD5"]]],
+                                    ["terms": ["checksums.value": ["970cfb0cffbe6ec4547b7df61af8987126a9cae8"]]]
                                 ]
                             ]
                         ]
@@ -699,12 +701,12 @@ class SearchRequestParserServiceTest extends Specification {
             must  : [:],
             filter: [
                 [nested: [
-                    path: 'links',
+                    path : 'links',
                     query: [
                         terms: [
                             'links.linkFunction': ["download"]
-                            ]
                         ]
+                    ]
                 ]]
             ]
         ]
@@ -726,13 +728,13 @@ class SearchRequestParserServiceTest extends Specification {
             must  : [:],
             filter: [
                 [
-                    "nested":[
-                        "path":"checksums",
-                        "query":[
-                            "bool" : [
-                                "must" : [
-                                    [ "terms" : ["checksums.algorithm" : ["SHA1"]] ],
-                                    [ "terms" : ["checksums.value" : ["387cfb0cffbe6ec4547b7df61af8987126a9cae8"]] ]
+                    "nested": [
+                        "path" : "checksums",
+                        "query": [
+                            "bool": [
+                                "must": [
+                                    ["terms": ["checksums.algorithm": ["SHA1"]]],
+                                    ["terms": ["checksums.value": ["387cfb0cffbe6ec4547b7df61af8987126a9cae8"]]]
                                 ]
                             ]
                         ]
@@ -749,77 +751,77 @@ class SearchRequestParserServiceTest extends Specification {
     when:
     def aggsResult = requestParser.createFacetAggregations()
     def expectedAggs = [
-        dataFormats   : [
-            terms         : [
+        dataFormats         : [
+            terms: [
                 field: 'dataFormat',
                 size : Integer.MAX_VALUE,
                 order: ['_term': 'asc']
             ]
         ],
-        linkProtocols     : [
-            nested: [
+        linkProtocols       : [
+            nested      : [
                 path: 'links'
             ],
             aggregations: [
                 foobar: [
                     terms: [
                         field: 'links.linkProtocol',
-                        size: Integer.MAX_VALUE,
+                        size : Integer.MAX_VALUE,
                         order: ['_term': 'asc']
                     ]
                 ]
             ]
         ],
         serviceLinkProtocols: [
-            terms         : [
+            terms: [
                 field: 'serviceLinkProtocol',
                 size : Integer.MAX_VALUE,
                 order: ['_term': 'asc']
             ]
         ],
-        science       : [
+        science             : [
             terms: [
                 field: 'gcmdScience',
                 size : Integer.MAX_VALUE,
                 order: ['_term': 'asc']
             ]
         ],
-        services       : [
+        services            : [
             terms: [
                 field: 'gcmdScienceServices',
                 size : Integer.MAX_VALUE,
                 order: ['_term': 'asc']
             ]
         ],
-        locations       : [
+        locations           : [
             terms: [
                 field: 'gcmdLocations',
                 size : Integer.MAX_VALUE,
                 order: ['_term': 'asc']
             ]
         ],
-        instruments   : [
+        instruments         : [
             terms: [
                 field: 'gcmdInstruments',
                 size : Integer.MAX_VALUE,
                 order: ['_term': 'asc']
             ]
         ],
-        platforms     : [
+        platforms           : [
             terms: [
                 field: 'gcmdPlatforms',
                 size : Integer.MAX_VALUE,
                 order: ['_term': 'asc']
             ]
         ],
-        projects      : [
+        projects            : [
             terms: [
                 field: 'gcmdProjects',
                 size : Integer.MAX_VALUE,
                 order: ['_term': 'asc']
             ]
         ],
-        dataCenters   : [
+        dataCenters         : [
             terms: [
                 field: 'gcmdDataCenters',
                 size : Integer.MAX_VALUE,
@@ -833,36 +835,36 @@ class SearchRequestParserServiceTest extends Specification {
                 order: ['_term': 'asc']
             ]
         ],
-        verticalResolution: [
+        verticalResolution  : [
             terms: [
                 field: 'gcmdVerticalResolution',
                 size : Integer.MAX_VALUE,
                 order: ['_term': 'asc']
             ]
         ],
-        temporalResolution: [
+        temporalResolution  : [
             terms: [
                 field: 'gcmdTemporalResolution',
                 size : Integer.MAX_VALUE,
                 order: ['_term': 'asc']
             ]
         ],
-        fileFormats: [
+        fileFormats         : [
             terms: [
                 field: 'fileFormat',
-                size: Integer.MAX_VALUE,
+                size : Integer.MAX_VALUE,
                 order: ['_term': 'asc']
             ]
         ],
-        linkAccessTypes: [
-            nested: [
+        linkAccessTypes     : [
+            nested      : [
                 path: 'links'
             ],
             aggregations: [
                 foobar: [
                     terms: [
                         field: 'links.linkFunction',
-                        size: Integer.MAX_VALUE,
+                        size : Integer.MAX_VALUE,
                         order: ['_term': 'asc']
                     ]
                 ]
@@ -878,120 +880,120 @@ class SearchRequestParserServiceTest extends Specification {
     when:
     def aggsResult = requestParser.createFacetAggregations()
     def expectedAggs = [
-        dataFormats   : [
-          terms         : [
-            field: 'dataFormat',
-            size : Integer.MAX_VALUE,
-            order: ['_term': 'asc']
-          ]
+        dataFormats         : [
+            terms: [
+                field: 'dataFormat',
+                size : Integer.MAX_VALUE,
+                order: ['_term': 'asc']
+            ]
         ],
-        linkProtocols     : [
-            nested: [
+        linkProtocols       : [
+            nested      : [
                 path: 'links'
             ],
             aggregations: [
                 foobar: [
                     terms: [
                         field: 'links.linkProtocol',
-                        size: Integer.MAX_VALUE,
+                        size : Integer.MAX_VALUE,
                         order: ['_term': 'asc']
                     ]
                 ]
             ]
         ],
         serviceLinkProtocols: [
-            terms         : [
+            terms: [
                 field: 'serviceLinkProtocol',
                 size : Integer.MAX_VALUE,
                 order: ['_term': 'asc']
             ]
         ],
-        science       : [
-            terms       : [
+        science             : [
+            terms: [
                 field: 'gcmdScience',
                 size : Integer.MAX_VALUE,
                 order: ['_term': 'asc']
             ]
         ],
-        services       : [
-            terms       : [
+        services            : [
+            terms: [
                 field: 'gcmdScienceServices',
                 size : Integer.MAX_VALUE,
                 order: ['_term': 'asc']
             ]
         ],
-        locations       : [
+        locations           : [
             terms: [
                 field: 'gcmdLocations',
                 size : Integer.MAX_VALUE,
                 order: ['_term': 'asc']
             ]
         ],
-        instruments   : [
-            terms       : [
+        instruments         : [
+            terms: [
                 field: 'gcmdInstruments',
                 size : Integer.MAX_VALUE,
                 order: ['_term': 'asc']
             ]
         ],
-        platforms     : [
-            terms       : [
+        platforms           : [
+            terms: [
                 field: 'gcmdPlatforms',
                 size : Integer.MAX_VALUE,
                 order: ['_term': 'asc']
             ]
         ],
-        projects      : [
-            terms       : [
+        projects            : [
+            terms: [
                 field: 'gcmdProjects',
                 size : Integer.MAX_VALUE,
                 order: ['_term': 'asc']
             ]
         ],
-        dataCenters   : [
-            terms       : [
+        dataCenters         : [
+            terms: [
                 field: 'gcmdDataCenters',
                 size : Integer.MAX_VALUE,
                 order: ['_term': 'asc']
             ]
         ],
         horizontalResolution: [
-            terms       : [
+            terms: [
                 field: 'gcmdHorizontalResolution',
                 size : Integer.MAX_VALUE,
                 order: ['_term': 'asc']
             ]
         ],
-        verticalResolution: [
-            terms       : [
+        verticalResolution  : [
+            terms: [
                 field: 'gcmdVerticalResolution',
                 size : Integer.MAX_VALUE,
                 order: ['_term': 'asc']
             ]
         ],
-        temporalResolution: [
-            terms       : [
+        temporalResolution  : [
+            terms: [
                 field: 'gcmdTemporalResolution',
                 size : Integer.MAX_VALUE,
                 order: ['_term': 'asc']
             ]
         ],
-        fileFormats: [
+        fileFormats         : [
             terms: [
                 field: 'fileFormat',
-                size: Integer.MAX_VALUE,
+                size : Integer.MAX_VALUE,
                 order: ['_term': 'asc']
             ]
         ],
-        linkAccessTypes: [
-            nested: [
+        linkAccessTypes     : [
+            nested      : [
                 path: 'links'
             ],
             aggregations: [
                 foobar: [
                     terms: [
                         field: 'links.linkFunction',
-                        size: Integer.MAX_VALUE,
+                        size : Integer.MAX_VALUE,
                         order: ['_term': 'asc']
                     ]
                 ]


### PR DESCRIPTION
closes #1430 

The big feature here is the addition of a `fieldQuery` query type, which takes a `field` and `value` to search against, and supports (single-level) nested fields. Unlike the full-text search, this is only useful for non-text fields and I added a boolean parameter to control whether the query is ran as a `match` or a `wildcard`, defaulting to `match`. In the `openapi.yml` I specifically included an enum whitelist of the valid `fields` you can query against, but I did not include app-level validation for that so it's only enforced at the schema validation level. I mostly did that because I wasn't sure if that was the best approach or if I should not have a whitelist at all and the search API user can just search against any field they want.

This PR also changes the `linkProtocols` facet to pull from the nested field `links.linkProtocol` instead of the `linkProtocol` field that we are pulling out separately. However, I did not remove the `linkProtocol` field from the search interfaces to try and keep in-line with our deprecation policy.