### PR TITLE
Search/Registry API forwarding at root endpoint

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -7293,9 +7293,9 @@
       }
     },
     "framer-motion": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-3.2.1.tgz",
-      "integrity": "sha512-5AWrh4JElgFAXWLqk0u8lVcdkigyuofyEy2LSsjuCxKbAb1hHqRn3PPdrV0KgPrysTHq95QO1bHFTLA7/Q8g+Q==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-3.3.0.tgz",
+      "integrity": "sha512-bjUrwXfMJZ6D+HSMDiXbMGKmlWGnUux8HotWgORTZkdPTgKAndlRXjeC2ikCgNVo2ifmRvEla5ckP9JaZc7JKA==",
       "requires": {
         "@emotion/is-prop-valid": "^0.8.2",
         "framesync": "^5.0.0",

--- a/registry/src/main/groovy/org/cedar/onestop/registry/api/RootController.groovy
+++ b/registry/src/main/groovy/org/cedar/onestop/registry/api/RootController.groovy
@@ -2,10 +2,12 @@ package org.cedar.onestop.registry.api
 
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 import javax.servlet.http.HttpServletResponse
+import javax.servlet.http.HttpServletRequest
 
 import static org.springframework.web.bind.annotation.RequestMethod.*
 
@@ -14,9 +16,16 @@ import static org.springframework.web.bind.annotation.RequestMethod.*
 @RestController
 class RootController {
 
+  private ApiRootGenerator apiLinkGenerator
+
+  @Autowired
+  MetadataRestController(ApiRootGenerator apiLinkGenerator) {
+    this.apiLinkGenerator = apiLinkGenerator
+  }
+
   @RequestMapping(path = "/", method = [GET, HEAD])
-  Map getApiRoot(HttpServletResponse response) {
-    return response.sendRedirect("openapi.yaml")
+  Map getApiRoot(HttpServletRequest request, HttpServletResponse response) {
+    return response.sendRedirect("${apiLinkGenerator.getApiRoot(request)}/openapi.yaml")
   }
 
 }

--- a/search/src/main/groovy/org/cedar/onestop/api/search/controller/DocumentationController.groovy
+++ b/search/src/main/groovy/org/cedar/onestop/api/search/controller/DocumentationController.groovy
@@ -8,27 +8,31 @@ import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
 import static org.springframework.web.bind.annotation.RequestMethod.GET
 import static org.springframework.web.bind.annotation.RequestMethod.HEAD
 
 import org.cedar.onestop.api.search.service.DocumentationService
+import org.cedar.onestop.api.search.service.ApiRootGenerator
 
 @Slf4j
 @RestController
 class DocumentationController {
 
   private ElasticsearchService elasticsearchService
+  private ApiRootGenerator apiLinkGenerator
 
   @Autowired
-  DocumentationController(ElasticsearchService elasticsearchService) {
+  DocumentationController(ElasticsearchService elasticsearchService, ApiRootGenerator apiLinkGenerator) {
     this.elasticsearchService = elasticsearchService
+    this.apiLinkGenerator = apiLinkGenerator
   }
 
   @RequestMapping(path = "/", method = [GET, HEAD])
-  Map getApiRoot(HttpServletResponse response) {
-    return response.sendRedirect("openapi.yaml")
+  Map getApiRoot(HttpServletRequest request, HttpServletResponse response) {
+    return response.sendRedirect("${apiLinkGenerator.getApiRoot(request)}/openapi.yaml")
   }
 
   @RequestMapping(path = ["/docs/attributes/collection", "/v1/docs/attributes/collection"], method = [GET, HEAD], produces = 'application/json')

--- a/search/src/main/groovy/org/cedar/onestop/api/search/service/ApiRootGenerator.groovy
+++ b/search/src/main/groovy/org/cedar/onestop/api/search/service/ApiRootGenerator.groovy
@@ -1,0 +1,48 @@
+package org.cedar.onestop.api.search.service
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+
+import javax.servlet.http.HttpServletRequest
+
+
+@Service
+class ApiRootGenerator {
+
+    private String apiRootUrl
+
+    ApiRootGenerator(@Value('${api.root.url:}') String apiRootUrl) {
+        this.apiRootUrl = apiRootUrl
+    }
+
+    String getApiRoot(HttpServletRequest request) {
+        if (!request) {
+            return null
+        }
+        if (apiRootUrl) {
+            return apiRootUrl
+        }
+
+        def forwarded = parseForwardedHeader(request.getHeader('forwarded'))
+        def proto = forwarded?.proto ?: request.getHeader('x-forwarded-proto') ?: request.getScheme()
+        def host = forwarded?.host ?: request.getHeader('x-forwarded-host') ?: request.getHeader('host')
+        def context = request.getContextPath()
+
+        return proto + '://' + host + context
+    }
+
+    Map parseForwardedHeader(String header) {
+        return header?.split(';')?.collectEntries({ String part ->
+            def i = part.indexOf('=')
+            if (i != -1) {
+                def key = part.substring(0, i).toLowerCase().trim().replaceAll('"', '')
+                def value = part.substring(i + 1).toLowerCase().trim().replaceAll('"', '')
+                if (key in ['host', 'proto']) {
+                    return [(key): value ?: null]
+                }
+            }
+            return [:]
+        })
+    }
+
+}

--- a/search/src/test/groovy/org/cedar/onestop/api/search/service/ApiRootGeneratorSpec.groovy
+++ b/search/src/test/groovy/org/cedar/onestop/api/search/service/ApiRootGeneratorSpec.groovy
@@ -1,0 +1,67 @@
+package org.cedar.onestop.api.search.service
+
+import org.springframework.mock.web.MockHttpServletRequest
+import spock.lang.Specification
+import spock.lang.Unroll
+
+@Unroll
+class ApiRootGeneratorSpec extends Specification {
+
+  private ApiRootGenerator apiRootGenerator = new ApiRootGenerator()
+  private MockHttpServletRequest mockRequest = new MockHttpServletRequest()
+
+  def setup() {
+    mockRequest.setProtocol('http')
+    mockRequest.addHeader('Host', 'localhost')
+  }
+
+  def 'parses host and protocol from the Forwarded header'() {
+    when:
+    def result = apiRootGenerator.parseForwardedHeader(header)
+
+    then:
+    println result
+
+    result.host == host
+    result.proto == proto
+
+    where:
+    host        | proto   | header
+    'testhost'  | 'http'  | 'host=testhost;proto=http'
+    'testhost'  | 'http'  | 'host=testhost; proto=http'
+    'testhost'  | 'http'  | 'host=testhost;proto="http"'
+    'testhost'  | 'http'  | 'host = testhost ; proto = "http"'
+    'testhost'  | 'http'  | 'host=testhost;proto=http;for=client1, proxy1, proxy2'
+    null        | 'http'  | 'proto=http'
+    'testhost'  | null    | 'host=testhost'
+    'testhost'  | null    | 'host=testhost; proto='
+  }
+
+  def 'returns api root with no headers'() {
+    expect:
+    apiRootGenerator.getApiRoot(mockRequest) == 'http://localhost'
+  }
+
+  def 'returns api root with Forwarded header'() {
+    mockRequest.addHeader('Forwarded', 'host=testhost;proto=https')
+
+    expect:
+    apiRootGenerator.getApiRoot(mockRequest) == 'https://testhost'
+  }
+
+  def 'returns api root with X-Forwarded-* headers'() {
+    mockRequest.addHeader('X-Forwarded-Host', 'testhost')
+    mockRequest.addHeader('X-Forwarded-Proto', 'https')
+
+    expect:
+    apiRootGenerator.getApiRoot(mockRequest) == 'https://testhost'
+  }
+
+  def 'applies context path to api root'() {
+    mockRequest.setContextPath('/testcontext')
+
+    expect:
+    apiRootGenerator.getApiRoot(mockRequest) == 'http://localhost/testcontext'
+  }
+
+}

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -76,6 +76,9 @@ build:
         roles:
           ROLE_ADMIN:
             - casuser
+      api:
+        root:
+          url: http://localhost/onestop/api/registry
     debug: "true"
     features.cas: "false"
     kafka.bootstrap.servers: PLAINTEXT://onestop-dev-cp-kafka:9092
@@ -123,6 +126,11 @@ build:
     service.nodePort: "30097"
     service.clusterIP: 10.100.100.2
     service.type: NodePort
+    config: |-
+      ---
+      api:
+        root:
+          url: http://localhost/onestop/api/registry
   imageStrategy:
     helm: {}
 .onestop-client: &onestop-client
@@ -210,10 +218,8 @@ deploy:
       - *onestop-parsalyzer
       - *onestop-search
       - *onestop-client
-      - *onestop-user
       - *onestop-gateway
       - *onestop-ingress
-      - *onestop-postgresql
       - name: onestop-dev
         chartPath: helm/onestop-dev
 profiles:
@@ -222,8 +228,9 @@ profiles:
       helm:
         releases:
           - *onestop-gateway
-          - *onestop-parsalyzer
           - *onestop-registry
+          - *onestop-ingress
+          - *onestop-search
           - name: onestop-dev
             chartPath: helm/onestop-dev
   - name: os

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -218,8 +218,10 @@ deploy:
       - *onestop-parsalyzer
       - *onestop-search
       - *onestop-client
+      - *onestop-user
       - *onestop-gateway
       - *onestop-ingress
+      - *onestop-postgresql
       - name: onestop-dev
         chartPath: helm/onestop-dev
 profiles:
@@ -228,9 +230,8 @@ profiles:
       helm:
         releases:
           - *onestop-gateway
+          - *onestop-parsalyzer
           - *onestop-registry
-          - *onestop-ingress
-          - *onestop-search
           - name: onestop-dev
             chartPath: helm/onestop-dev
   - name: os

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -130,7 +130,7 @@ build:
       ---
       api:
         root:
-          url: http://localhost/onestop/api/registry
+          url: http://localhost/onestop/api/search
   imageStrategy:
     helm: {}
 .onestop-client: &onestop-client


### PR DESCRIPTION
Basically all I did was copy the `ApiRootGenerator` service that existed in `registry` into `search`, and then utilized the `api.root.url` Spring config value to provide an API root prefix for both `registry` and `search` to create the proper URL for redirecting to their respective `opanapi.yaml` documents.