### PR TITLE
1313 named save search

### DIFF
--- a/client/src/components/common/dialog/ModalFormUncontrolled.jsx
+++ b/client/src/components/common/dialog/ModalFormUncontrolled.jsx
@@ -29,7 +29,6 @@ export default function ModalFormUncontrolled({
   onClose, // from Chakra useDisclosure
   onSubmit,
   onCancel,
-  question,
   submitText,
   cancelText,
   title,
@@ -48,14 +47,21 @@ export default function ModalFormUncontrolled({
   )
 
   const formInputs = inputs.map(inp => {
-    const label = inp.label ? <label key={`${inp.name}::label`} htmlFor={inp.id}>{inp.label}</label> : null
+    const label = inp.label ? (
+      <label
+        key={`${inp.name}::label`}
+        htmlFor={inp.id}
+        style={{marginRight: '0.5em'}}
+      >
+        {inp.label}
+      </label>
+    ) : null
     const extraProps = inp.extraProps || {}
 
     return (
       <FlexRow
         rowId={`${inp.name}Row`}
         key={`${inp.name}::row`}
-        style={{justifyContent: 'center'}}
         items={[
           label,
           <input
@@ -86,26 +92,24 @@ export default function ModalFormUncontrolled({
           >
             <SvgIcon size="1em" path={times} />
           </ModalCloseButton>
-          <ModalBody>{question}</ModalBody>
+          <form role="form" onSubmit={submitForm}>
+            <ModalBody>{formInputs}</ModalBody>
 
-          <ModalFooter>
-            <form role="form" onSubmit={submitForm} style={{width: '100%'}}>
-              {formInputs}
+            <ModalFooter>
               <FlexRow
-                rowId='modalFormActionButtons'
-                key='modalFormActionButtons'
-                style={{justifyContent: 'center'}}
+                rowId="modalFormActionButtons"
+                key="modalFormActionButtons"
                 items={[
                   <Button
                     role="button"
-                    key='modalFormActionButtons::submit'
+                    key="modalFormActionButtons::submit"
                     text={submitText || 'Save'}
                     style={styleButton}
                     styleFocus={styleButtonFocus}
                   />,
                   <Button
                     role="button"
-                    key='modalFormActionButtons::cancel'
+                    key="modalFormActionButtons::cancel"
                     text={cancelText || 'Cancel'}
                     style={styleButton}
                     styleFocus={styleButtonFocus}
@@ -118,8 +122,8 @@ export default function ModalFormUncontrolled({
                   />,
                 ]}
               />
-            </form>
-          </ModalFooter>
+            </ModalFooter>
+          </form>
         </ModalContent>
       </ModalOverlay>
     </Modal>

--- a/client/src/components/common/dialog/ModalFormUncontrolled.jsx
+++ b/client/src/components/common/dialog/ModalFormUncontrolled.jsx
@@ -48,19 +48,24 @@ export default function ModalFormUncontrolled({
   )
 
   const formInputs = inputs.map(inp => {
-    const label = inp.label ? <label htmlFor={inp.id}>{inp.label}</label> : null
+    const label = inp.label ? <label key={`${inp.name}::label`} htmlFor={inp.id}>{inp.label}</label> : null
+    const extraProps = inp.extraProps || {}
 
     return (
       <FlexRow
         rowId={`${inp.name}Row`}
+        key={`${inp.name}::row`}
         style={{justifyContent: 'center'}}
         items={[
           label,
           <input
+            key={`${inp.name}::input`}
             id={inp.id}
             name={inp.name}
             type={inp.type}
             style={inp.style || {}}
+            value={inp.initialValue}
+            {...extraProps}
           />,
         ]}
       />
@@ -87,17 +92,20 @@ export default function ModalFormUncontrolled({
             <form role="form" onSubmit={submitForm} style={{width: '100%'}}>
               {formInputs}
               <FlexRow
-                rowId={'modalFormActionButtons'}
+                rowId='modalFormActionButtons'
+                key='modalFormActionButtons'
                 style={{justifyContent: 'center'}}
                 items={[
                   <Button
                     role="button"
+                    key='modalFormActionButtons::submit'
                     text={submitText || 'Save'}
                     style={styleButton}
                     styleFocus={styleButtonFocus}
                   />,
                   <Button
                     role="button"
+                    key='modalFormActionButtons::cancel'
                     text={cancelText || 'Cancel'}
                     style={styleButton}
                     styleFocus={styleButtonFocus}

--- a/client/src/components/common/dialog/ModalFormUncontrolled.jsx
+++ b/client/src/components/common/dialog/ModalFormUncontrolled.jsx
@@ -1,0 +1,119 @@
+import React from 'react'
+import {times, SvgIcon} from '../SvgIcon'
+import Button from '../input/Button'
+import FlexRow from '../ui/FlexRow'
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  ModalCloseButton,
+} from '@chakra-ui/core'
+
+const styleButtonFocus = {
+  outline: '2px dashed black',
+  outlineOffset: '2px',
+}
+
+const styleButton = {
+  padding: '0.309em',
+  margin: '0.105em',
+  borderRadius: '0.309em',
+  fontSize: '1em',
+}
+
+export default function ModalFormUncontrolled({
+  isOpen, // from Chakra useDisclosure
+  onClose, // from Chakra useDisclosure
+  onSubmit,
+  onCancel,
+  question,
+  submitText,
+  cancelText,
+  title,
+  inputs,
+}){
+  const submitForm = React.useCallback(
+    event => {
+      event.preventDefault()
+      const form = event.currentTarget
+      if (onSubmit && form) {
+        onSubmit(new FormData(form))
+      }
+      onClose()
+    },
+    [ onSubmit ]
+  )
+
+  const formInputs = inputs.map(inp => {
+    const label = inp.label ? <label htmlFor={inp.id}>{inp.label}</label> : null
+
+    return (
+      <FlexRow
+        rowId={`${inp.name}Row`}
+        style={{justifyContent: 'center'}}
+        items={[
+          label,
+          <input
+            id={inp.id}
+            name={inp.name}
+            type={inp.type}
+            style={inp.style || {}}
+          />,
+        ]}
+      />
+    )
+  })
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} isCentered>
+      <ModalOverlay backgroundColor="#5d5d5d94">
+        <ModalContent maxWidth="28em" borderRadius="0.309em" padding="0.309em">
+          <ModalHeader>
+            <h1>{title}</h1>
+          </ModalHeader>
+          <ModalCloseButton
+            backgroundColor="#00000000"
+            border="none"
+            _focus={styleButtonFocus}
+          >
+            <SvgIcon size="1em" path={times} />
+          </ModalCloseButton>
+          <ModalBody>{question}</ModalBody>
+
+          <ModalFooter>
+            <form role="form" onSubmit={submitForm} style={{width: '100%'}}>
+              {formInputs}
+              <FlexRow
+                rowId={'modalFormActionButtons'}
+                style={{justifyContent: 'center'}}
+                items={[
+                  <Button
+                    role="button"
+                    text={submitText || 'Save'}
+                    style={styleButton}
+                    styleFocus={styleButtonFocus}
+                  />,
+                  <Button
+                    role="button"
+                    text={cancelText || 'Cancel'}
+                    style={styleButton}
+                    styleFocus={styleButtonFocus}
+                    onClick={() => {
+                      if (onCancel) {
+                        onCancel()
+                      }
+                      onClose()
+                    }}
+                  />,
+                ]}
+              />
+            </form>
+          </ModalFooter>
+        </ModalContent>
+      </ModalOverlay>
+    </Modal>
+  )
+}

--- a/client/src/components/results/collections/Collections.jsx
+++ b/client/src/components/results/collections/Collections.jsx
@@ -221,7 +221,9 @@ export default function Collections(props){
     },
   ]
 
-  const modalQuestion = `Do you want to ${savedId ? 'delete' : 'save'} this search?`
+  const modalTitle = `Do you want to ${savedId
+    ? 'delete'
+    : 'save'} this search?`
 
   return (
     <div style={styleCollections}>
@@ -233,8 +235,7 @@ export default function Collections(props){
       <ModalFormUncontrolled
         isOpen={isOpen}
         onClose={onClose}
-        title={'Save search'}
-        question={modalQuestion}
+        title={modalTitle}
         submitText={savedId ? 'Delete' : 'Save'}
         cancelText={'Cancel'}
         inputs={formInputs}

--- a/client/src/components/results/granules/GranuleItem.jsx
+++ b/client/src/components/results/granules/GranuleItem.jsx
@@ -89,9 +89,7 @@ export default function GranuleItem(props){
 
   const xmlLink = (
     <a
-      href={
-        getApiRegistryPath() + '/metadata/granule/' + itemId + '/raw/xml'
-      }
+      href={getApiRegistryPath() + '/metadata/granule/' + itemId + '/raw/xml'}
       target={'_blank'}
     >
       XML

--- a/client/test/components/common/dialog/ModalFormUncontrolled.test.jsx
+++ b/client/test/components/common/dialog/ModalFormUncontrolled.test.jsx
@@ -1,50 +1,49 @@
 import React from 'react'
 import {mount} from 'enzyme'
-import { useDisclosure, ModalBody } from '@chakra-ui/core'
+import {useDisclosure, ModalHeader} from '@chakra-ui/core'
 
 import ModalFormUncontrolled from '../../../../src/components/common/dialog/ModalFormUncontrolled'
 
 describe('ModalFormUncontrolled', () => {
   let component = null
   let wrapper = null
-  const question = "This is a test question?"
   const submitText = 'Submit'
-  const cancelText = "Cancel"
-  const title = "This Is A Title"
+  const cancelText = 'Cancel'
+  const title = 'This Is A Title'
   const inputs = [
     {
       label: 'Text Input1:',
       id: 'textInput1',
       name: 'textInput1',
       type: 'text',
-      initialValue: "textValue1",
-      extraProps: { readOnly: true } // Added 'readOnly' prop to appease React errors
+      initialValue: 'textValue1',
+      extraProps: {readOnly: true}, // Added 'readOnly' prop to appease React errors
     },
     {
-      label: "Radio Input1:",
+      label: 'Radio Input1:',
       id: 'radioInput1',
       name: 'radioInput1',
       type: 'radio',
       initialValue: 'radioValue1',
-      extraProps: { checked: true, readOnly: true }
+      extraProps: {checked: true, readOnly: true},
     },
     {
-      label: "Check Input1:",
-      id: "checkInput1",
-      name: "checkInput1",
-      type: "checkbox",
+      label: 'Check Input1:',
+      id: 'checkInput1',
+      name: 'checkInput1',
+      type: 'checkbox',
       initialValue: 'checkValue1',
-      extraProps: { checked: true, readOnly: true }
-    }
+      extraProps: {checked: true, readOnly: true},
+    },
   ]
 
-  const onSubmit = (formData) => {
+  const onSubmit = formData => {
     // This onSubmit function gets called when you run .simulate('submit') on the form element
     expect(Array.from(formData.entries())).toEqual(
       expect.arrayContaining([
-        ['textInput1', 'textValue1'],
-        ['radioInput1', 'radioValue1'],
-        ['checkInput1', 'checkValue1']
+        [ 'textInput1', 'textValue1' ],
+        [ 'radioInput1', 'radioValue1' ],
+        [ 'checkInput1', 'checkValue1' ],
       ])
     )
   }
@@ -56,14 +55,15 @@ describe('ModalFormUncontrolled', () => {
       const {isOpen, onOpen, onClose} = useDisclosure()
 
       // Have a single useEffect to call onOpen() after this wrapper gets mounted
-      React.useEffect(() => { onOpen() }, [])
+      React.useEffect(() => {
+        onOpen()
+      }, [])
 
       const props = {
         isOpen,
         onClose,
         onSubmit,
         onCancel,
-        question,
         submitText,
         cancelText,
         title,
@@ -82,9 +82,9 @@ describe('ModalFormUncontrolled', () => {
     expect(h1.length).toBe(1)
     expect(h1.text()).toBe(title)
 
-    const body = component.find(ModalBody)
+    const body = component.find(ModalHeader)
     expect(body.length).toBe(1)
-    expect(body.text()).toBe(question)
+    expect(body.text()).toBe(title)
 
     const form = component.find('form')
     expect(form.length).toBe(1)

--- a/client/test/components/common/dialog/ModalFormUncontrolled.test.jsx
+++ b/client/test/components/common/dialog/ModalFormUncontrolled.test.jsx
@@ -1,0 +1,111 @@
+import React from 'react'
+import {mount} from 'enzyme'
+import { useDisclosure, ModalBody } from '@chakra-ui/core'
+
+import ModalFormUncontrolled from '../../../../src/components/common/dialog/ModalFormUncontrolled'
+
+describe('ModalFormUncontrolled', () => {
+  let component = null
+  let wrapper = null
+  const question = "This is a test question?"
+  const submitText = 'Submit'
+  const cancelText = "Cancel"
+  const title = "This Is A Title"
+  const inputs = [
+    {
+      label: 'Text Input1:',
+      id: 'textInput1',
+      name: 'textInput1',
+      type: 'text',
+      initialValue: "textValue1",
+      extraProps: { readOnly: true } // Added 'readOnly' prop to appease React errors
+    },
+    {
+      label: "Radio Input1:",
+      id: 'radioInput1',
+      name: 'radioInput1',
+      type: 'radio',
+      initialValue: 'radioValue1',
+      extraProps: { checked: true, readOnly: true }
+    },
+    {
+      label: "Check Input1:",
+      id: "checkInput1",
+      name: "checkInput1",
+      type: "checkbox",
+      initialValue: 'checkValue1',
+      extraProps: { checked: true, readOnly: true }
+    }
+  ]
+
+  const onSubmit = (formData) => {
+    // This onSubmit function gets called when you run .simulate('submit') on the form element
+    expect(Array.from(formData.entries())).toEqual(
+      expect.arrayContaining([
+        ['textInput1', 'textValue1'],
+        ['radioInput1', 'radioValue1'],
+        ['checkInput1', 'checkValue1']
+      ])
+    )
+  }
+  const onCancel = jest.fn(() => {})
+
+  beforeAll(() => {
+    // Create a wrapper component so that we can call the useDisclosure() hook
+    const FormWrapper = () => {
+      const {isOpen, onOpen, onClose} = useDisclosure()
+
+      // Have a single useEffect to call onOpen() after this wrapper gets mounted
+      React.useEffect(() => { onOpen() }, [])
+
+      const props = {
+        isOpen,
+        onClose,
+        onSubmit,
+        onCancel,
+        question,
+        submitText,
+        cancelText,
+        title,
+        inputs,
+      }
+      return <ModalFormUncontrolled {...props} />
+    }
+
+    wrapper = mount(<FormWrapper />)
+    wrapper.update()
+    component = wrapper.find(ModalFormUncontrolled).at(0)
+  })
+
+  it('should output the provided string props as text', () => {
+    const h1 = component.find('h1')
+    expect(h1.length).toBe(1)
+    expect(h1.text()).toBe(title)
+
+    const body = component.find(ModalBody)
+    expect(body.length).toBe(1)
+    expect(body.text()).toBe(question)
+
+    const form = component.find('form')
+    expect(form.length).toBe(1)
+
+    const buttons = form.find('button')
+    expect(buttons.length).toBe(2)
+    const submitButton = buttons.at(0)
+    const cancelButton = buttons.at(1)
+    expect(submitButton.text()).toBe(submitText)
+    expect(cancelButton.text()).toBe(cancelText)
+  })
+
+  it('should serialize its inputs as FormData onSubmit', () => {
+    const form = component.find('form')
+    form.simulate('submit')
+  })
+
+  it('should call the provided onCancel function when not submitted', () => {
+    const form = component.find('form')
+    const cancelButton = form.find('button').at(1)
+    cancelButton.simulate('click')
+    expect(onCancel).toBeCalledTimes(1)
+  })
+})


### PR DESCRIPTION
The big feature added is a `ModalFormUncontrolled` component. I copied most of the `OneStopDialog` component and then tweaked things around to allow for an `inputs` prop, which is an array of objects defining a few fields to create a pair of `<label>` and `<input>` elements inside a modal form. These inputs are uncontrolled to make it simpler to use the component, however I can easily see wanting a controlled version for any future functionality that needs to be more complicated.

I am also not totally convinced the `inputs` prop should be a list of objects (basically a list of input specs). Instead it could be a list of arbitrary components similar to how the `FlexRow` component works. But again, adding that kind of flexibility might be better suited to a future use-case when it is needed.

closes #1313  